### PR TITLE
Implement DB-backed conversation history

### DIFF
--- a/internal/bot/user.go
+++ b/internal/bot/user.go
@@ -41,10 +41,10 @@ func StartUserBot(db *sql.DB, aiClient *ai.AIClient, token string) {
 		}
 
 		// 2) Сохраняем вопрос пользователя в историю
-		conversation.AppendHistory(chatID, "user", userText)
+		conversation.AppendHistory(db, chatID, "user", userText)
 
 		// 3) Сохраняем ответ бота в историю
-		conversation.AppendHistory(chatID, "assistant", answer)
+		conversation.AppendHistory(db, chatID, "assistant", answer)
 
 		// 4) Отправляем ответ
 		bot.Send(tgbotapi.NewMessage(chatID, answer))

--- a/internal/conversation/history.go
+++ b/internal/conversation/history.go
@@ -1,7 +1,9 @@
 package conversation
 
 import (
-	"sync"
+	"context"
+	"database/sql"
+	"log"
 )
 
 // HistoryItem — одна запись истории (пользователь или бот).
@@ -10,30 +12,46 @@ type HistoryItem struct {
 	Content string
 }
 
-// historyStore хранит карты chatID → []HistoryItem
-var (
-	historyStore = make(map[int64][]HistoryItem)
-	historyMu    sync.Mutex
-)
-
-// AppendHistory добавляет новый элемент в историю конкретного чата.
-func AppendHistory(chatID int64, role, text string) {
-	historyMu.Lock()
-	defer historyMu.Unlock()
-	historyStore[chatID] = append(historyStore[chatID], HistoryItem{Role: role, Content: text})
-	// Если хочется ограничить длину истории (например, максимум 20 сообщений), можно:
-	if len(historyStore[chatID]) > 20 {
-		historyStore[chatID] = historyStore[chatID][len(historyStore[chatID])-20:]
+// AppendHistory добавляет новый элемент в историю конкретного чата в БД.
+func AppendHistory(db *sql.DB, chatID int64, role, text string) {
+	if db == nil {
+		return
+	}
+	_, err := db.ExecContext(context.Background(),
+		`INSERT INTO conversation_history(chat_id, role, content) VALUES ($1, $2, $3)`,
+		chatID, role, text,
+	)
+	if err != nil {
+		log.Printf("append history error: %v", err)
 	}
 }
 
-// GetHistory возвращает копию истории чата.
-func GetHistory(chatID int64) []HistoryItem {
-	historyMu.Lock()
-	defer historyMu.Unlock()
-	// Копируем срез, чтобы не дать внешнему коду править исходный
-	items := historyStore[chatID]
-	result := make([]HistoryItem, len(items))
-	copy(result, items)
-	return result
+// GetHistory возвращает последние 20 сообщений чата из БД.
+func GetHistory(db *sql.DB, chatID int64) []HistoryItem {
+	if db == nil {
+		return nil
+	}
+	rows, err := db.QueryContext(context.Background(),
+		`SELECT role, content FROM conversation_history
+         WHERE chat_id=$1 ORDER BY id DESC LIMIT 20`, chatID)
+	if err != nil {
+		log.Printf("get history query error: %v", err)
+		return nil
+	}
+	defer rows.Close()
+
+	var items []HistoryItem
+	for rows.Next() {
+		var it HistoryItem
+		if err := rows.Scan(&it.Role, &it.Content); err != nil {
+			log.Printf("get history scan error: %v", err)
+			return items
+		}
+		items = append(items, it)
+	}
+	// Результат идёт в обратном порядке, разворачиваем
+	for i, j := 0, len(items)-1; i < j; i, j = i+1, j-1 {
+		items[i], items[j] = items[j], items[i]
+	}
+	return items
 }

--- a/internal/db/migration.sql
+++ b/internal/db/migration.sql
@@ -6,5 +6,14 @@ CREATE EXTENSION IF NOT EXISTS vector;
 CREATE TABLE IF NOT EXISTS chunks (
                                       id SERIAL PRIMARY KEY,
                                       content TEXT NOT NULL,
-                                      embedding VECTOR(1536) NOT NULL
+    embedding VECTOR(1536) NOT NULL
     );
+
+-- Храним историю сообщений пользователей и бота
+CREATE TABLE IF NOT EXISTS conversation_history (
+    id SERIAL PRIMARY KEY,
+    chat_id BIGINT NOT NULL,
+    role TEXT NOT NULL,
+    content TEXT NOT NULL,
+    created_at TIMESTAMPTZ DEFAULT NOW()
+);

--- a/internal/handler/question.go
+++ b/internal/handler/question.go
@@ -21,7 +21,7 @@ func ProcessQuestionWithHistory(
 	var histText string
 	if chatID != 0 {
 		// 1) Получаем всю историю сообщений для этого chatID
-		history := conversation.GetHistory(chatID)
+		history := conversation.GetHistory(db, chatID)
 
 		// 2) Формируем блок истории в виде текста
 		//    Например:


### PR DESCRIPTION
## Summary
- store conversation history in Postgres
- fetch last messages from the database for prompt building

## Testing
- `go vet ./...`
- `go build ./...`


------
https://chatgpt.com/codex/tasks/task_e_683fb670765083318c001fa0d09e5cbd