### PR TITLE
Add chat viewer and conversation summaries

### DIFF
--- a/internal/conversation/session.go
+++ b/internal/conversation/session.go
@@ -1,0 +1,77 @@
+package conversation
+
+import (
+	"context"
+	"database/sql"
+	"log"
+)
+
+type ChatInfo struct {
+	ChatID  int64
+	Summary sql.NullString
+}
+
+// EnsureSession makes sure a record exists for the given chatID and returns its uuid.
+func EnsureSession(db *sql.DB, chatID int64) (string, error) {
+	if db == nil {
+		return "", nil
+	}
+	var uuid string
+	err := db.QueryRowContext(context.Background(), `SELECT uuid FROM conversations WHERE chat_id=$1`, chatID).Scan(&uuid)
+	if err == sql.ErrNoRows {
+		err = db.QueryRowContext(context.Background(), `INSERT INTO conversations(chat_id) VALUES($1) RETURNING uuid`, chatID).Scan(&uuid)
+	}
+	if err != nil {
+		log.Printf("ensure session error: %v", err)
+		return "", err
+	}
+	return uuid, nil
+}
+
+// GetChatInfoByUUID returns chat id and summary by uuid.
+func GetChatInfoByUUID(db *sql.DB, uuid string) (ChatInfo, error) {
+	var info ChatInfo
+	if db == nil {
+		return info, sql.ErrConnDone
+	}
+	err := db.QueryRowContext(context.Background(), `SELECT chat_id, summary FROM conversations WHERE uuid=$1`, uuid).Scan(&info.ChatID, &info.Summary)
+	if err != nil {
+		return info, err
+	}
+	return info, nil
+}
+
+// UpdateSummary saves summary for chat.
+func UpdateSummary(db *sql.DB, chatID int64, summary string) {
+	if db == nil {
+		return
+	}
+	_, err := db.ExecContext(context.Background(), `UPDATE conversations SET summary=$1, updated_at=NOW() WHERE chat_id=$2`, summary, chatID)
+	if err != nil {
+		log.Printf("update summary error: %v", err)
+	}
+}
+
+// GetFullHistory returns entire chat history in chronological order.
+func GetFullHistory(db *sql.DB, chatID int64) []HistoryItem {
+	if db == nil {
+		return nil
+	}
+	rows, err := db.QueryContext(context.Background(), `SELECT role, content FROM conversation_history WHERE chat_id=$1 ORDER BY id ASC`, chatID)
+	if err != nil {
+		log.Printf("get full history query error: %v", err)
+		return nil
+	}
+	defer rows.Close()
+
+	var items []HistoryItem
+	for rows.Next() {
+		var it HistoryItem
+		if err := rows.Scan(&it.Role, &it.Content); err != nil {
+			log.Printf("get full history scan error: %v", err)
+			return items
+		}
+		items = append(items, it)
+	}
+	return items
+}

--- a/internal/db/migrations/0002_conversations.sql
+++ b/internal/db/migrations/0002_conversations.sql
@@ -1,0 +1,14 @@
+-- +goose Up
+CREATE EXTENSION IF NOT EXISTS pgcrypto;
+
+CREATE TABLE IF NOT EXISTS conversations (
+    uuid UUID PRIMARY KEY DEFAULT gen_random_uuid(),
+    chat_id BIGINT NOT NULL UNIQUE,
+    summary TEXT,
+    updated_at TIMESTAMPTZ
+);
+
+CREATE INDEX IF NOT EXISTS conversations_chat_id_idx ON conversations(chat_id);
+
+-- +goose Down
+DROP TABLE IF EXISTS conversations;

--- a/internal/handler/chat.go
+++ b/internal/handler/chat.go
@@ -1,0 +1,61 @@
+package handler
+
+import (
+	"database/sql"
+	"html/template"
+	"net/http"
+	"strings"
+
+	"ragbot/internal/conversation"
+)
+
+var chatTemplate = template.Must(template.New("chat").Parse(`<!DOCTYPE html>
+<html>
+<head>
+<meta charset="utf-8">
+<script src="https://cdn.tailwindcss.com"></script>
+<title>Chat</title>
+</head>
+<body class="bg-gray-100">
+<div class="max-w-2xl mx-auto p-4">
+    {{if .Summary}}
+    <div class="bg-yellow-100 p-3 rounded shadow mb-4">
+        <h2 class="font-bold mb-2">Summary</h2>
+        <p>{{.Summary}}</p>
+    </div>
+    {{end}}
+    <div class="bg-white p-4 rounded shadow">
+        {{range .History}}
+        <div class="mb-2">
+            {{if eq .Role "user"}}
+            <span class="font-semibold">User:</span>
+            {{else}}
+            <span class="text-blue-600">Assistant:</span>
+            {{end}}
+            <span>{{.Content}}</span>
+        </div>
+        {{end}}
+    </div>
+</div>
+</body>
+</html>`))
+
+func ChatHandler(db *sql.DB) http.HandlerFunc {
+	return func(w http.ResponseWriter, r *http.Request) {
+		uuid := strings.TrimPrefix(r.URL.Path, "/chat/")
+		info, err := conversation.GetChatInfoByUUID(db, uuid)
+		if err != nil {
+			http.NotFound(w, r)
+			return
+		}
+		history := conversation.GetFullHistory(db, info.ChatID)
+		data := struct {
+			Summary string
+			History []conversation.HistoryItem
+		}{
+			Summary: info.Summary.String,
+			History: history,
+		}
+		chatTemplate.Execute(w, data)
+	}
+}

--- a/internal/handler/http.go
+++ b/internal/handler/http.go
@@ -18,7 +18,7 @@ type QueryResponse struct {
 	Answer string `json:"answer"`
 }
 
-// StartHTTP запускает HTTP-сервер с endpoint-ами /health и /query
+// StartHTTP запускает HTTP-сервер с endpoint-ами /health, /query и /chat/{uuid}
 func StartHTTP(db *sql.DB, aiClient *ai.AIClient) {
 	http.HandleFunc("/health", func(w http.ResponseWriter, _ *http.Request) {
 		w.WriteHeader(http.StatusOK)
@@ -42,6 +42,8 @@ func StartHTTP(db *sql.DB, aiClient *ai.AIClient) {
 		w.Header().Set("Content-Type", "application/json")
 		json.NewEncoder(w).Encode(QueryResponse{Answer: answer})
 	})
+
+	http.HandleFunc("/chat/", ChatHandler(db))
 
 	log.Println("HTTP server listening on :8080")
 	log.Fatal(http.ListenAndServe(":8080", nil))


### PR DESCRIPTION
## Summary
- keep track of chats in new `conversations` table
- show full conversation history at `/chat/{uuid}`
- generate summary when user calls manager
- expose chat page via HTTP server

## Testing
- `go test ./...`

------
https://chatgpt.com/codex/tasks/task_e_6841098a73d483318238325442ac5513