### PR TITLE
Add unique constraint and source column

### DIFF
--- a/internal/bot/admin.go
+++ b/internal/bot/admin.go
@@ -107,8 +107,9 @@ func StartAdminBot(db *sql.DB, token string, allowedIDs []int64) {
 		default:
 			content := strings.Trim(text, " ")
 			_, _ = db.ExecContext(context.Background(),
-				"INSERT INTO chunks(content) VALUES($1)",
+				"INSERT INTO chunks(content, source) VALUES($1, $2) ON CONFLICT (content) DO NOTHING",
 				content,
+				"admin",
 			)
 			adminBot.Send(tgbotapi.NewMessage(chatID, "Добавлено"))
 		}

--- a/internal/db/migrations/0005_chunks_source.sql
+++ b/internal/db/migrations/0005_chunks_source.sql
@@ -1,0 +1,9 @@
+-- +goose Up
+ALTER TABLE chunks ADD COLUMN IF NOT EXISTS source TEXT DEFAULT '';
+CREATE INDEX IF NOT EXISTS chunks_source_idx ON chunks(source);
+CREATE UNIQUE INDEX IF NOT EXISTS chunks_content_uidx ON chunks(content);
+
+-- +goose Down
+DROP INDEX IF EXISTS chunks_content_uidx;
+DROP INDEX IF EXISTS chunks_source_idx;
+ALTER TABLE chunks DROP COLUMN IF EXISTS source;

--- a/internal/education/file_source.go
+++ b/internal/education/file_source.go
@@ -52,7 +52,9 @@ func (f *FileSource) process(db *sql.DB) {
 		if line == "" {
 			continue
 		}
-		_, err := db.ExecContext(context.Background(), "INSERT INTO chunks(content) VALUES($1)", line)
+		_, err := db.ExecContext(context.Background(),
+			"INSERT INTO chunks(content, source) VALUES($1, $2) ON CONFLICT (content) DO NOTHING",
+			line, f.Path)
 		if err != nil {
 			log.Printf("file source insert error: %v", err)
 		}


### PR DESCRIPTION
## Summary
- prevent duplicate knowledge fragments by making `content` column unique
- allow distinguishing chunks from different sources via new `source` column
- update admin and file sources to gracefully ignore duplicate inserts

## Testing
- `go vet ./...`
- `go test ./...`


------
https://chatgpt.com/codex/tasks/task_e_684279ecd8b88331b8be1e69cdaf40a9