### PR TITLE
Add Yandex YML knowledge source

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,6 +10,7 @@
 - ADMIN_TELEGRAM_TOKEN
 - ADMIN_CHAT_IDS
 - EDU_FILE_PATH (optional path to file with knowledge source)
+- YANDEX_YML_URL (optional link to yandex.yml file)
 - USE_EXTERNAL_SOURCE (set to "true" to enable external DB source)
 
 ## Установка
@@ -33,6 +34,7 @@
   ADMIN_TELEGRAM_TOKEN=your_admin_telegram_token
   ADMIN_CHAT_IDS=your_admin_chat_ids_separated_by_commas
   EDU_FILE_PATH=path_to_optional_file
+  YANDEX_YML_URL=https://example.com/yandex.yml
   USE_EXTERNAL_SOURCE=true
   ```
 

--- a/cmd/ragbot/main.go
+++ b/cmd/ragbot/main.go
@@ -45,6 +45,9 @@ func main() {
 	if cfg.EducationFilePath != "" {
 		sources = append(sources, &education.FileSource{Path: cfg.EducationFilePath, Interval: time.Hour})
 	}
+	if cfg.YandexYMLURL != "" {
+		sources = append(sources, &education.YandexYMLSource{URL: cfg.YandexYMLURL, Interval: time.Hour})
+	}
 	if cfg.UseExternalSource {
 		sources = append(sources, &education.ExternalDBSource{})
 	}

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -17,6 +17,7 @@ type AppConfig struct {
 	AdminChatIDs       []int64
 	EducationFilePath  string
 	UseExternalSource  bool
+	YandexYMLURL       string
 }
 
 type AppSettings struct {
@@ -63,6 +64,7 @@ func LoadConfig() *AppConfig {
 	}
 
 	eduFile := os.Getenv("EDUCATION_FILE_PATH")
+	ymlURL := os.Getenv("YANDEX_YML_URL")
 	useExternal := false
 	if os.Getenv("USE_EXTERNAL_SOURCE") == "true" {
 		useExternal = true
@@ -91,6 +93,7 @@ func LoadConfig() *AppConfig {
 		AdminChatIDs:       adminIDs,
 		EducationFilePath:  eduFile,
 		UseExternalSource:  useExternal,
+		YandexYMLURL:       ymlURL,
 	}
 
 	return Config

--- a/internal/db/migrations/0006_chunks_ext_id.sql
+++ b/internal/db/migrations/0006_chunks_ext_id.sql
@@ -1,0 +1,7 @@
+-- +goose Up
+ALTER TABLE chunks ADD COLUMN IF NOT EXISTS ext_id TEXT;
+CREATE INDEX IF NOT EXISTS chunks_ext_id_idx ON chunks(ext_id);
+
+-- +goose Down
+DROP INDEX IF EXISTS chunks_ext_id_idx;
+ALTER TABLE chunks DROP COLUMN IF EXISTS ext_id;

--- a/internal/education/yandex_yml_source.go
+++ b/internal/education/yandex_yml_source.go
@@ -1,0 +1,127 @@
+package education
+
+import (
+	"context"
+	"database/sql"
+	"encoding/xml"
+	"io"
+	"log"
+	"net/http"
+	"time"
+
+	"ragbot/internal/util"
+)
+
+type YandexYMLSource struct {
+	URL      string
+	Interval time.Duration
+}
+
+func (y *YandexYMLSource) Start(ctx context.Context, db *sql.DB) {
+	go y.run(ctx, db)
+}
+
+func (y *YandexYMLSource) run(ctx context.Context, db *sql.DB) {
+	defer util.Recover("YandexYMLSource.run")
+	y.process(db)
+	ticker := time.NewTicker(y.Interval)
+	defer ticker.Stop()
+	for {
+		select {
+		case <-ctx.Done():
+			return
+		case <-ticker.C:
+			y.process(db)
+		}
+	}
+}
+
+type ymlCatalog struct {
+	Date string  `xml:"date,attr"`
+	Shop ymlShop `xml:"shop"`
+}
+
+type ymlShop struct {
+	Offers []ymlOffer `xml:"offers>offer"`
+}
+
+type ymlOffer struct {
+	ID          string `xml:"id,attr"`
+	CategoryID  string `xml:"categoryId"`
+	Name        string `xml:"name"`
+	Description string `xml:"description"`
+}
+
+func (y *YandexYMLSource) process(db *sql.DB) {
+	defer util.Recover("YandexYMLSource.process")
+	resp, err := http.Get(y.URL)
+	if err != nil {
+		log.Printf("yandex yml fetch error: %v", err)
+		return
+	}
+	defer resp.Body.Close()
+
+	body, err := io.ReadAll(resp.Body)
+	if err != nil {
+		log.Printf("yandex yml read error: %v", err)
+		return
+	}
+
+	var catalog ymlCatalog
+	if err := xml.Unmarshal(body, &catalog); err != nil {
+		log.Printf("yandex yml parse error: %v", err)
+		return
+	}
+
+	pubDate, err := time.Parse(time.RFC3339, catalog.Date)
+	if err != nil {
+		log.Printf("yandex yml date parse error: %v", err)
+		return
+	}
+
+	for _, offer := range catalog.Shop.Offers {
+		if offer.CategoryID != "1" && offer.CategoryID != "2" {
+			continue
+		}
+
+		var content string
+		switch offer.CategoryID {
+		case "1":
+			content = "Класс " + offer.Name + ": " + offer.Description
+		case "2":
+			content = "Абонемент " + offer.Name + ": " + offer.Description
+		}
+
+		extID := offer.CategoryID + ":" + offer.ID
+		var id int
+		var createdAt time.Time
+		err := db.QueryRowContext(context.Background(),
+			"SELECT id, created_at FROM chunks WHERE source=$1 AND ext_id=$2",
+			"yandex.yml", extID).Scan(&id, &createdAt)
+		if err == sql.ErrNoRows {
+			_, err = db.ExecContext(context.Background(),
+				"INSERT INTO chunks(content, source, ext_id, created_at) VALUES($1,$2,$3,$4)",
+				content, "yandex.yml", extID, pubDate)
+			if err != nil {
+				log.Printf("yandex yml insert error: %v", err)
+			} else {
+				log.Printf("Chunk added from yandex.yml: %s", extID)
+			}
+			continue
+		}
+		if err != nil {
+			log.Printf("yandex yml select error: %v", err)
+			continue
+		}
+		if pubDate.After(createdAt) {
+			_, err = db.ExecContext(context.Background(),
+				"UPDATE chunks SET content=$1, created_at=$2, embedding=NULL, processed_at=NULL WHERE id=$3",
+				content, pubDate, id)
+			if err != nil {
+				log.Printf("yandex yml update error: %v", err)
+			} else {
+				log.Printf("Chunk updated from yandex.yml: %s", extID)
+			}
+		}
+	}
+}


### PR DESCRIPTION
## Summary
- add migration for `chunks.ext_id`
- parse yandex.yml files hourly
- support `YANDEX_YML_URL` config option
- hook new source in `main.go`
- document new config parameter

## Testing
- `go vet ./...`


------
https://chatgpt.com/codex/tasks/task_e_68428b4b4990833188dd17714fba7eba