### PR TITLE
Add amoCRM deal integration

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,6 +12,7 @@
 - EDUCATION_FILE_PATH (optional path to file with knowledge source)
 - YANDEX_YML_URL (optional link to yandex.yml file)
 - USE_EXTERNAL_SOURCE (set to "true" to enable external DB source)
+- AMO_WEBHOOK_URL (optional link to amoCRM incoming webhook)
 
 ## Установка
 
@@ -34,9 +35,10 @@
    ADMIN_TELEGRAM_TOKEN=your_admin_telegram_token
    ADMIN_CHAT_IDS=your_admin_chat_ids_separated_by_commas
    EDUCATION_FILE_PATH=path_to_optional_file
-   YANDEX_YML_URL=https://example.com/yandex.yml
-   USE_EXTERNAL_SOURCE=true
-   ```
+  YANDEX_YML_URL=https://example.com/yandex.yml
+  USE_EXTERNAL_SOURCE=true
+  AMO_WEBHOOK_URL=https://example.amocrm.ru/api/v2/pipeline/webhook/123/456
+  ```
 
 ## Запуск
 

--- a/internal/amo/client.go
+++ b/internal/amo/client.go
@@ -1,0 +1,30 @@
+package amo
+
+import (
+	"net/http"
+	"net/url"
+)
+
+// SendLead sends a lead request to amoCRM digital pipeline webhook.
+// webhookURL should contain full URL to the incoming hook.
+func SendLead(webhookURL, name, phone, comment string) error {
+	if webhookURL == "" {
+		return nil
+	}
+	data := url.Values{}
+	if name != "" {
+		data.Set("name", name)
+	}
+	if phone != "" {
+		data.Set("phone", phone)
+	}
+	if comment != "" {
+		data.Set("text", comment)
+	}
+	resp, err := http.PostForm(webhookURL, data)
+	if err != nil {
+		return err
+	}
+	defer resp.Body.Close()
+	return nil
+}

--- a/internal/bot/user.go
+++ b/internal/bot/user.go
@@ -11,6 +11,7 @@ import (
 
 	tgbotapi "github.com/go-telegram-bot-api/telegram-bot-api/v5"
 	ai "ragbot/internal/ai"
+	"ragbot/internal/amo"
 	"ragbot/internal/handler" // поправлен импорт
 	"ragbot/internal/util"
 )
@@ -96,6 +97,13 @@ func StartUserBot(dbConn *sql.DB, AIClient *ai.AIClient, token string) {
 				delete(contactSteps, chatID)
 				stateMu.Unlock()
 				reply(chatID, "Наш менеджер свяжется с вами в ближайшее время")
+				info, err := conversation.GetChatInfoByChatID(db, chatID)
+				if err == nil {
+					link := fmt.Sprintf("%s/chat/%s", config.Config.BaseURL, info.ID)
+					adminMsg := fmt.Sprintf("%s (%s): %s\n\n%s", info.Name.String, info.Phone.String, info.Summary.String, link)
+					SendToAllAdmins(adminMsg)
+					amo.SendLead(config.Config.AmoWebhookURL, info.Name.String, info.Phone.String, info.Summary.String+"\n\n"+link)
+				}
 				continue
 			}
 		}

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -18,6 +18,7 @@ type AppConfig struct {
 	EducationFilePath  string
 	UseExternalSource  bool
 	YandexYMLURL       string
+	AmoWebhookURL      string
 }
 
 type AppSettings struct {
@@ -66,6 +67,7 @@ func LoadConfig() *AppConfig {
 
 	eduFile := os.Getenv("EDUCATION_FILE_PATH")
 	ymlURL := os.Getenv("YANDEX_YML_URL")
+	amoURL := os.Getenv("AMO_WEBHOOK_URL")
 	useExternal := false
 	if os.Getenv("USE_EXTERNAL_SOURCE") == "true" {
 		useExternal = true
@@ -95,6 +97,7 @@ func LoadConfig() *AppConfig {
 		EducationFilePath:  eduFile,
 		UseExternalSource:  useExternal,
 		YandexYMLURL:       ymlURL,
+		AmoWebhookURL:      amoURL,
 	}
 
 	return Config


### PR DESCRIPTION
## Summary
- add AMO_WEBHOOK_URL env variable
- send new lead to amoCRM when client leaves contact info

## Testing
- `go test ./...`


------
https://chatgpt.com/codex/tasks/task_e_68429bdd19a08331bd555e1783183b94