### PR TITLE
Add source names for DB insert

### DIFF
--- a/internal/bot/admin.go
+++ b/internal/bot/admin.go
@@ -11,6 +11,8 @@ import (
 	"strings"
 )
 
+const source = "admin"
+
 func init() {
 	//sync.Once{}
 }
@@ -109,7 +111,7 @@ func StartAdminBot(db *sql.DB, token string, allowedIDs []int64) {
 			_, _ = db.ExecContext(context.Background(),
 				"INSERT INTO chunks(content, source) VALUES($1, $2) ON CONFLICT (content) DO NOTHING",
 				content,
-				"admin",
+				source,
 			)
 			adminBot.Send(tgbotapi.NewMessage(chatID, "Добавлено"))
 		}

--- a/internal/education/file_source.go
+++ b/internal/education/file_source.go
@@ -12,6 +12,8 @@ import (
 	"ragbot/internal/util"
 )
 
+const fileSource = "file"
+
 // FileSource loads chunks from a text file on a schedule.
 type FileSource struct {
 	Path     string
@@ -54,7 +56,7 @@ func (f *FileSource) process(db *sql.DB) {
 		}
 		rows, err := db.QueryContext(context.Background(),
 			"INSERT INTO chunks(content, source) VALUES($1, $2) ON CONFLICT (content) DO NOTHING RETURNING content",
-			line, f.Path)
+			line, fileSource)
 		if err != nil {
 			log.Printf("file source insert error: %v", err)
 		}

--- a/internal/education/yandex_yml_source.go
+++ b/internal/education/yandex_yml_source.go
@@ -12,7 +12,7 @@ import (
 	"ragbot/internal/util"
 )
 
-const source = "yandex.yml"
+const yandexSource = "yandex.yml"
 
 type YandexYMLSource struct {
 	URL      string
@@ -100,11 +100,11 @@ func (y *YandexYMLSource) process(db *sql.DB) {
 
 		err := db.QueryRowContext(context.Background(),
 			"SELECT id, created_at FROM chunks WHERE source=$1 AND ext_id=$2",
-			source, extID).Scan(&id, &createdAt)
+			yandexSource, extID).Scan(&id, &createdAt)
 		if err == sql.ErrNoRows {
 			_, err = db.ExecContext(context.Background(),
 				"INSERT INTO chunks(content, source, ext_id, created_at) VALUES($1,$2,$3,$4)",
-				content, source, extID, pubDate)
+				content, yandexSource, extID, pubDate)
 			if err != nil {
 				log.Printf("yandex.yml insert error: %v", err)
 			} else {


### PR DESCRIPTION
## Summary
- set a `source` name for admin bot inserts
- store a fixed source identifier for `FileSource`
- rename constant in `YandexYMLSource` to avoid conflicts

## Testing
- `go test ./...`


------
https://chatgpt.com/codex/tasks/task_e_6842afc4abf083318ab1f3891cf720dc