### PR TITLE
Integrate AMO CRM API for leads

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,7 +12,8 @@
 - EDUCATION_FILE_PATH (optional path to file with knowledge source)
 - YANDEX_YML_URL (optional link to yandex.yml file)
 - USE_EXTERNAL_SOURCE (set to "true" to enable external DB source)
-- AMO_WEBHOOK_URL (optional link to amoCRM incoming webhook)
+- AMO_DOMAIN (domain like `example.amocrm.ru`)
+- AMO_ACCESS_TOKEN (OAuth access token for amoCRM API)
 
 ## Установка
 
@@ -37,7 +38,8 @@
    EDUCATION_FILE_PATH=path_to_optional_file
   YANDEX_YML_URL=https://example.com/yandex.yml
   USE_EXTERNAL_SOURCE=true
-  AMO_WEBHOOK_URL=https://example.amocrm.ru/api/v2/pipeline/webhook/123/456
+  AMO_DOMAIN=example.amocrm.ru
+  AMO_ACCESS_TOKEN=your_access_token
   ```
 
 ## Запуск

--- a/internal/amo/client.go
+++ b/internal/amo/client.go
@@ -1,30 +1,118 @@
 package amo
 
 import (
+	"bytes"
+	"encoding/json"
+	"fmt"
+	"io"
 	"net/http"
-	"net/url"
 )
 
-// SendLead sends a lead request to amoCRM digital pipeline webhook.
-// webhookURL should contain full URL to the incoming hook.
-func SendLead(webhookURL, name, phone, comment string) error {
-	if webhookURL == "" {
+// SendLead creates a lead in amoCRM using the API v4.
+// domain should be like "example.amocrm.ru" without protocol.
+// accessToken is the OAuth2 access token for the account.
+func SendLead(domain, accessToken, name, phone, comment string) error {
+	if domain == "" || accessToken == "" {
 		return nil
 	}
-	data := url.Values{}
-	if name != "" {
-		data.Set("name", name)
+
+	// Build request body for POST /api/v4/leads/complex
+	type value struct {
+		Value    string `json:"value"`
+		EnumCode string `json:"enum_code"`
 	}
-	if phone != "" {
-		data.Set("phone", phone)
+	type cf struct {
+		FieldCode string  `json:"field_code"`
+		Values    []value `json:"values"`
 	}
-	if comment != "" {
-		data.Set("text", comment)
+	type contact struct {
+		FirstName          string `json:"first_name,omitempty"`
+		CustomFieldsValues []cf   `json:"custom_fields_values,omitempty"`
 	}
-	resp, err := http.PostForm(webhookURL, data)
+	type embed struct {
+		Contacts []contact `json:"contacts,omitempty"`
+	}
+	lead := struct {
+		Name     string `json:"name,omitempty"`
+		Embedded embed  `json:"_embedded,omitempty"`
+	}{
+		Name: name,
+		Embedded: embed{
+			Contacts: []contact{
+				{
+					FirstName: name,
+					CustomFieldsValues: []cf{
+						{
+							FieldCode: "PHONE",
+							Values:    []value{{Value: phone, EnumCode: "WORK"}},
+						},
+					},
+				},
+			},
+		},
+	}
+
+	body, err := json.Marshal([]any{lead})
+	if err != nil {
+		return err
+	}
+	url := fmt.Sprintf("https://%s/api/v4/leads/complex", domain)
+	req, err := http.NewRequest("POST", url, bytes.NewReader(body))
+	if err != nil {
+		return err
+	}
+	req.Header.Set("Authorization", "Bearer "+accessToken)
+	req.Header.Set("Content-Type", "application/json")
+	resp, err := http.DefaultClient.Do(req)
 	if err != nil {
 		return err
 	}
 	defer resp.Body.Close()
+	if resp.StatusCode >= http.StatusBadRequest {
+		data, _ := io.ReadAll(resp.Body)
+		return fmt.Errorf("amoCRM lead create failed: %s: %s", resp.Status, string(data))
+	}
+
+	var lr struct {
+		Embedded struct {
+			Leads []struct {
+				ID int `json:"id"`
+			} `json:"leads"`
+		} `json:"_embedded"`
+	}
+	if err := json.NewDecoder(resp.Body).Decode(&lr); err != nil {
+		return err
+	}
+	if comment == "" || len(lr.Embedded.Leads) == 0 {
+		return nil
+	}
+
+	// Add a note with the comment
+	noteURL := fmt.Sprintf("https://%s/api/v4/leads/%d/notes", domain, lr.Embedded.Leads[0].ID)
+	noteBody := []map[string]any{
+		{
+			"note_type": "common",
+			"params":    map[string]string{"text": comment},
+		},
+	}
+	nb, err := json.Marshal(noteBody)
+	if err != nil {
+		return err
+	}
+	req, err = http.NewRequest("POST", noteURL, bytes.NewReader(nb))
+	if err != nil {
+		return err
+	}
+	req.Header.Set("Authorization", "Bearer "+accessToken)
+	req.Header.Set("Content-Type", "application/json")
+	resp2, err := http.DefaultClient.Do(req)
+	if err != nil {
+		return err
+	}
+	defer resp2.Body.Close()
+	if resp2.StatusCode >= http.StatusBadRequest {
+		data, _ := io.ReadAll(resp2.Body)
+		return fmt.Errorf("amoCRM add note failed: %s: %s", resp2.Status, string(data))
+	}
 	return nil
 }

--- a/internal/bot/user.go
+++ b/internal/bot/user.go
@@ -102,7 +102,7 @@ func StartUserBot(dbConn *sql.DB, AIClient *ai.AIClient, token string) {
 					link := fmt.Sprintf("%s/chat/%s", config.Config.BaseURL, info.ID)
 					adminMsg := fmt.Sprintf("%s (%s): %s\n\n%s", info.Name.String, info.Phone.String, info.Summary.String, link)
 					SendToAllAdmins(adminMsg)
-					amo.SendLead(config.Config.AmoWebhookURL, info.Name.String, info.Phone.String, info.Summary.String+"\n\n"+link)
+					amo.SendLead(config.Config.AmoDomain, config.Config.AmoAccessToken, info.Name.String, info.Phone.String, info.Summary.String+"\n\n"+link)
 				}
 				continue
 			}

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -18,7 +18,9 @@ type AppConfig struct {
 	EducationFilePath  string
 	UseExternalSource  bool
 	YandexYMLURL       string
-	AmoWebhookURL      string
+	AmoWebhookURL      string // deprecated
+	AmoDomain          string
+	AmoAccessToken     string
 }
 
 type AppSettings struct {
@@ -67,7 +69,9 @@ func LoadConfig() *AppConfig {
 
 	eduFile := os.Getenv("EDUCATION_FILE_PATH")
 	ymlURL := os.Getenv("YANDEX_YML_URL")
-	amoURL := os.Getenv("AMO_WEBHOOK_URL")
+	amoURL := os.Getenv("AMO_WEBHOOK_URL") // deprecated
+	amoDomain := os.Getenv("AMO_DOMAIN")
+	amoToken := os.Getenv("AMO_ACCESS_TOKEN")
 	useExternal := false
 	if os.Getenv("USE_EXTERNAL_SOURCE") == "true" {
 		useExternal = true
@@ -98,6 +102,8 @@ func LoadConfig() *AppConfig {
 		UseExternalSource:  useExternal,
 		YandexYMLURL:       ymlURL,
 		AmoWebhookURL:      amoURL,
+		AmoDomain:          amoDomain,
+		AmoAccessToken:     amoToken,
 	}
 
 	return Config


### PR DESCRIPTION
## Summary
- implement lead creation using amoCRM API v4 and add notes
- extend configuration with AMO_DOMAIN and AMO_ACCESS_TOKEN
- update Telegram bot to call new SendLead
- document new credentials in README

## Testing
- `go test ./...`
- `go vet ./...`
- `go build ./...`


------
https://chatgpt.com/codex/tasks/task_e_6842b4faf390833181377c1aeb042dd1