### PR TITLE
Centralize DB logic in repository

### DIFF
--- a/internal/conversation/history.go
+++ b/internal/conversation/history.go
@@ -2,56 +2,24 @@ package conversation
 
 import (
 	"context"
-	"database/sql"
 	"log"
+
+	"ragbot/internal/repository"
 )
 
-// HistoryItem — одна запись истории (пользователь или бот).
-type HistoryItem struct {
-	Role    string // "user" или "assistant"
-	Content string
-}
+type HistoryItem = repository.HistoryItem
 
-// AppendHistory добавляет новый элемент в историю конкретного чата в БД.
-func AppendHistory(db *sql.DB, chatID int64, role, text string) {
-	if db == nil {
-		return
-	}
-	_, err := db.ExecContext(context.Background(),
-		`INSERT INTO conversation_history(chat_id, role, content) VALUES ($1, $2, $3)`,
-		chatID, role, text,
-	)
-	if err != nil {
+func AppendHistory(repo *repository.Repository, chatID int64, role, text string) {
+	if err := repo.AppendHistory(context.Background(), chatID, role, text); err != nil {
 		log.Printf("append history error: %v", err)
 	}
 }
 
-// GetHistory возвращает последние 20 сообщений чата из БД.
-func GetHistory(db *sql.DB, chatID int64) []HistoryItem {
-	if db == nil {
-		return nil
-	}
-	rows, err := db.QueryContext(context.Background(),
-		`SELECT role, content FROM conversation_history
-         WHERE chat_id=$1 ORDER BY id DESC LIMIT 20`, chatID)
+func GetHistory(repo *repository.Repository, chatID int64) []HistoryItem {
+	items, err := repo.GetHistory(context.Background(), chatID, 20)
 	if err != nil {
 		log.Printf("get history query error: %v", err)
 		return nil
-	}
-	defer rows.Close()
-
-	var items []HistoryItem
-	for rows.Next() {
-		var it HistoryItem
-		if err := rows.Scan(&it.Role, &it.Content); err != nil {
-			log.Printf("get history scan error: %v", err)
-			return items
-		}
-		items = append(items, it)
-	}
-	// Результат идёт в обратном порядке, разворачиваем
-	for i, j := 0, len(items)-1; i < j; i, j = i+1, j-1 {
-		items[i], items[j] = items[j], items[i]
 	}
 	return items
 }

--- a/internal/conversation/session.go
+++ b/internal/conversation/session.go
@@ -2,28 +2,15 @@ package conversation
 
 import (
 	"context"
-	"database/sql"
 	"log"
+
+	"ragbot/internal/repository"
 )
 
-type ChatInfo struct {
-	ID      string
-	ChatID  int64
-	Summary sql.NullString
-	Name    sql.NullString
-	Phone   sql.NullString
-}
+type ChatInfo = repository.ChatInfo
 
-// EnsureSession makes sure a record exists for the given chatID and returns its uuid.
-func EnsureSession(db *sql.DB, chatID int64) (string, error) {
-	if db == nil {
-		return "", nil
-	}
-	var uuid string
-	err := db.QueryRowContext(context.Background(), `SELECT uuid FROM conversations WHERE chat_id=$1`, chatID).Scan(&uuid)
-	if err == sql.ErrNoRows {
-		err = db.QueryRowContext(context.Background(), `INSERT INTO conversations(chat_id) VALUES($1) RETURNING uuid`, chatID).Scan(&uuid)
-	}
+func EnsureSession(repo *repository.Repository, chatID int64) (string, error) {
+	uuid, err := repo.EnsureSession(context.Background(), chatID)
 	if err != nil {
 		log.Printf("ensure session error: %v", err)
 		return "", err
@@ -31,84 +18,37 @@ func EnsureSession(db *sql.DB, chatID int64) (string, error) {
 	return uuid, nil
 }
 
-func GetChatInfoByChatID(db *sql.DB, chatID int64) (ChatInfo, error) {
-	var info ChatInfo
-	if db == nil {
-		return info, sql.ErrConnDone
-	}
-	err := db.QueryRowContext(context.Background(), `SELECT uuid, summary, name, phone FROM conversations WHERE chat_id=$1`, chatID).Scan(&info.ID, &info.Summary, &info.Name, &info.Phone)
-	if err != nil {
-		return info, err
-	}
-	return info, nil
+func GetChatInfoByChatID(repo *repository.Repository, chatID int64) (ChatInfo, error) {
+	return repo.GetChatInfoByChatID(context.Background(), chatID)
 }
 
-// GetChatInfoByUUID returns chat id and summary by uuid.
-func GetChatInfoByUUID(db *sql.DB, uuid string) (ChatInfo, error) {
-	var info ChatInfo
-	if db == nil {
-		return info, sql.ErrConnDone
-	}
-	err := db.QueryRowContext(context.Background(), `SELECT chat_id, summary, name, phone FROM conversations WHERE uuid=$1`, uuid).Scan(&info.ChatID, &info.Summary, &info.Name, &info.Phone)
-	if err != nil {
-		return info, err
-	}
-	return info, nil
+func GetChatInfoByUUID(repo *repository.Repository, uuid string) (ChatInfo, error) {
+	return repo.GetChatInfoByUUID(context.Background(), uuid)
 }
 
-// UpdateSummary saves summary for chat.
-func UpdateSummary(db *sql.DB, chatID int64, summary string) {
-	if db == nil {
-		return
-	}
-	_, err := db.ExecContext(context.Background(), `UPDATE conversations SET summary=$1, updated_at=NOW() WHERE chat_id=$2`, summary, chatID)
-	if err != nil {
+func UpdateSummary(repo *repository.Repository, chatID int64, summary string) {
+	if err := repo.UpdateSummary(context.Background(), chatID, summary); err != nil {
 		log.Printf("update summary error: %v", err)
 	}
 }
 
-// UpdateName saves user name for chat.
-func UpdateName(db *sql.DB, chatID int64, name string) {
-	if db == nil {
-		return
-	}
-	_, err := db.ExecContext(context.Background(), `UPDATE conversations SET name=$1, updated_at=NOW() WHERE chat_id=$2`, name, chatID)
-	if err != nil {
+func UpdateName(repo *repository.Repository, chatID int64, name string) {
+	if err := repo.UpdateName(context.Background(), chatID, name); err != nil {
 		log.Printf("update name error: %v", err)
 	}
 }
 
-// UpdatePhone saves phone number for chat.
-func UpdatePhone(db *sql.DB, chatID int64, phone string) {
-	if db == nil {
-		return
-	}
-	_, err := db.ExecContext(context.Background(), `UPDATE conversations SET phone=$1, updated_at=NOW() WHERE chat_id=$2`, phone, chatID)
-	if err != nil {
+func UpdatePhone(repo *repository.Repository, chatID int64, phone string) {
+	if err := repo.UpdatePhone(context.Background(), chatID, phone); err != nil {
 		log.Printf("update phone error: %v", err)
 	}
 }
 
-// GetFullHistory returns entire chat history in chronological order.
-func GetFullHistory(db *sql.DB, chatID int64) []HistoryItem {
-	if db == nil {
-		return nil
-	}
-	rows, err := db.QueryContext(context.Background(), `SELECT role, content FROM conversation_history WHERE chat_id=$1 ORDER BY id ASC`, chatID)
+func GetFullHistory(repo *repository.Repository, chatID int64) []HistoryItem {
+	items, err := repo.GetFullHistory(context.Background(), chatID)
 	if err != nil {
 		log.Printf("get full history query error: %v", err)
 		return nil
-	}
-	defer rows.Close()
-
-	var items []HistoryItem
-	for rows.Next() {
-		var it HistoryItem
-		if err := rows.Scan(&it.Role, &it.Content); err != nil {
-			log.Printf("get full history scan error: %v", err)
-			return items
-		}
-		items = append(items, it)
 	}
 	return items
 }

--- a/internal/education/admin_source.go
+++ b/internal/education/admin_source.go
@@ -2,8 +2,9 @@ package education
 
 import (
 	"context"
-	"database/sql"
+
 	"ragbot/internal/bot"
+	"ragbot/internal/repository"
 )
 
 // AdminSource wraps the admin Telegram bot as a knowledge source.
@@ -12,7 +13,6 @@ type AdminSource struct {
 	AllowedIDs []int64
 }
 
-func (a *AdminSource) Start(ctx context.Context, db *sql.DB) {
-	// bot.StartAdminBot blocks, so run it in a goroutine
-	go bot.StartAdminBot(db, a.Token, a.AllowedIDs)
+func (a *AdminSource) Start(ctx context.Context, repo *repository.Repository) {
+	go bot.StartAdminBot(repo, a.Token, a.AllowedIDs)
 }

--- a/internal/education/external_source.go
+++ b/internal/education/external_source.go
@@ -2,13 +2,14 @@ package education
 
 import (
 	"context"
-	"database/sql"
 	"log"
+
+	"ragbot/internal/repository"
 )
 
 // ExternalDBSource is a stub for future external DB integration.
 type ExternalDBSource struct{}
 
-func (e *ExternalDBSource) Start(ctx context.Context, db *sql.DB) {
+func (e *ExternalDBSource) Start(ctx context.Context, repo *repository.Repository) {
 	log.Println("ExternalDBSource not implemented yet")
 }

--- a/internal/education/source.go
+++ b/internal/education/source.go
@@ -2,10 +2,11 @@ package education
 
 import (
 	"context"
-	"database/sql"
+
+	"ragbot/internal/repository"
 )
 
 // Source defines a knowledge source that can load chunks into the database.
 type Source interface {
-	Start(ctx context.Context, db *sql.DB)
+	Start(ctx context.Context, repo *repository.Repository)
 }

--- a/internal/education/yandex_yml_source.go
+++ b/internal/education/yandex_yml_source.go
@@ -2,13 +2,13 @@ package education
 
 import (
 	"context"
-	"database/sql"
 	"encoding/xml"
 	"io"
 	"log"
 	"net/http"
 	"time"
 
+	"ragbot/internal/repository"
 	"ragbot/internal/util"
 )
 
@@ -19,13 +19,13 @@ type YandexYMLSource struct {
 	Interval time.Duration
 }
 
-func (y *YandexYMLSource) Start(ctx context.Context, db *sql.DB) {
-	go y.run(ctx, db)
+func (y *YandexYMLSource) Start(ctx context.Context, repo *repository.Repository) {
+	go y.run(ctx, repo)
 }
 
-func (y *YandexYMLSource) run(ctx context.Context, db *sql.DB) {
+func (y *YandexYMLSource) run(ctx context.Context, repo *repository.Repository) {
 	defer util.Recover("YandexYMLSource.run")
-	y.process(db)
+	y.process(repo)
 	ticker := time.NewTicker(y.Interval)
 	defer ticker.Stop()
 	for {
@@ -33,7 +33,7 @@ func (y *YandexYMLSource) run(ctx context.Context, db *sql.DB) {
 		case <-ctx.Done():
 			return
 		case <-ticker.C:
-			y.process(db)
+			y.process(repo)
 		}
 	}
 }
@@ -54,7 +54,7 @@ type ymlOffer struct {
 	Description string `xml:"description"`
 }
 
-func (y *YandexYMLSource) process(db *sql.DB) {
+func (y *YandexYMLSource) process(repo *repository.Repository) {
 	defer util.Recover("YandexYMLSource.process")
 	resp, err := http.Get(y.URL)
 	if err != nil {
@@ -95,16 +95,13 @@ func (y *YandexYMLSource) process(db *sql.DB) {
 		}
 
 		extID := offer.CategoryID + ":" + offer.ID
-		var id int
-		var createdAt time.Time
-
-		err := db.QueryRowContext(context.Background(),
-			"SELECT id, created_at FROM chunks WHERE source=$1 AND ext_id=$2",
-			yandexSource, extID).Scan(&id, &createdAt)
-		if err == sql.ErrNoRows {
-			_, err = db.ExecContext(context.Background(),
-				"INSERT INTO chunks(content, source, ext_id, created_at) VALUES($1,$2,$3,$4)",
-				content, yandexSource, extID, pubDate)
+		id, createdAt, found, err := repo.GetChunkByExtID(context.Background(), yandexSource, extID)
+		if err != nil {
+			log.Printf("yandex.yml select error: %v", err)
+			continue
+		}
+		if !found {
+			err = repo.InsertChunkWithExtID(context.Background(), content, yandexSource, extID, pubDate)
 			if err != nil {
 				log.Printf("yandex.yml insert error: %v", err)
 			} else {
@@ -112,14 +109,8 @@ func (y *YandexYMLSource) process(db *sql.DB) {
 			}
 			continue
 		}
-		if err != nil {
-			log.Printf("yandex.yml select error: %v", err)
-			continue
-		}
 		if pubDate.After(createdAt) {
-			_, err = db.ExecContext(context.Background(),
-				"UPDATE chunks SET content=$1, created_at=$2, embedding=NULL, processed_at=NULL WHERE id=$3",
-				content, pubDate, id)
+			err = repo.UpdateChunkWithCreatedAt(context.Background(), id, content, pubDate)
 			if err != nil {
 				log.Printf("yandex.yml update error: %v", err)
 			} else {

--- a/internal/embedding/worker.go
+++ b/internal/embedding/worker.go
@@ -2,54 +2,43 @@ package embedding
 
 import (
 	"context"
-	"database/sql"
 	"log"
 	"time"
 
-	"github.com/pgvector/pgvector-go"
 	ai "ragbot/internal/ai"
+	"ragbot/internal/repository"
 	"ragbot/internal/util"
 )
 
 // StartWorker runs a goroutine that periodically embeds unprocessed chunks.
-func StartWorker(db *sql.DB, aiClient *ai.AIClient) {
+func StartWorker(repo *repository.Repository, aiClient *ai.AIClient) {
 	go func() {
 		defer util.Recover("embedding worker")
 		ticker := time.NewTicker(time.Minute)
 		defer ticker.Stop()
 		for {
-			process(db, aiClient)
+			process(repo, aiClient)
 			<-ticker.C
 		}
 	}()
 }
 
-func process(db *sql.DB, aiClient *ai.AIClient) {
+func process(repo *repository.Repository, aiClient *ai.AIClient) {
 	defer util.Recover("embedding process")
-	rows, err := db.QueryContext(context.Background(), "SELECT id, content FROM chunks WHERE processed_at IS NULL LIMIT 5")
+	chunks, err := repo.GetUnprocessedChunks(context.Background(), 5)
 	if err != nil {
 		log.Printf("embedding worker query error: %v", err)
 		return
 	}
-	defer rows.Close()
-
-	for rows.Next() {
-		var id int
-		var content string
-		if err := rows.Scan(&id, &content); err != nil {
-			log.Printf("embedding worker scan error: %v", err)
-			continue
-		}
-		emb, err := aiClient.GenerateEmbedding(content)
+	for _, ch := range chunks {
+		emb, err := aiClient.GenerateEmbedding(ch.Content)
 		if err != nil {
 			log.Printf("embedding generation error: %v", err)
 			continue
 		}
-		_, err = db.ExecContext(context.Background(), "UPDATE chunks SET embedding=$1, processed_at=NOW() WHERE id=$2", pgvector.NewVector(emb), id)
-		if err != nil {
+		if err := repo.UpdateChunkEmbedding(context.Background(), ch.ID, emb); err != nil {
 			log.Printf("embedding update error: %v", err)
 		}
-		// small delay to avoid rate limits
 		time.Sleep(200 * time.Millisecond)
 	}
 }

--- a/internal/handler/chat.go
+++ b/internal/handler/chat.go
@@ -1,12 +1,12 @@
 package handler
 
 import (
-	"database/sql"
 	"html/template"
 	"net/http"
 	"strings"
 
 	"ragbot/internal/conversation"
+	"ragbot/internal/repository"
 	"ragbot/internal/util"
 )
 
@@ -23,9 +23,9 @@ var chatTemplate = template.Must(template.New("chat").Parse(`<!DOCTYPE html>
     <div class="bg-yellow-100 p-3 rounded shadow mb-4">
         <h2 class="font-bold mb-2">Контакт</h2>
         <p>{{.Name}}</p>
-		{{if .Phone}}
-		<p>{{.Phone}}</p>
-		{{end}}
+                {{if .Phone}}
+                <p>{{.Phone}}</p>
+                {{end}}
     </div>
     {{end}}
     {{if .Summary}}
@@ -50,16 +50,16 @@ var chatTemplate = template.Must(template.New("chat").Parse(`<!DOCTYPE html>
 </body>
 </html>`))
 
-func ChatHandler(db *sql.DB) http.HandlerFunc {
+func ChatHandler(repo *repository.Repository) http.HandlerFunc {
 	return func(w http.ResponseWriter, r *http.Request) {
 		defer util.Recover("ChatHandler")
 		uuid := strings.TrimPrefix(strings.TrimSuffix(r.URL.Path, "/"), "/chat/")
-		info, err := conversation.GetChatInfoByUUID(db, uuid)
+		info, err := conversation.GetChatInfoByUUID(repo, uuid)
 		if err != nil {
 			http.NotFound(w, r)
 			return
 		}
-		history := conversation.GetFullHistory(db, info.ChatID)
+		history := conversation.GetFullHistory(repo, info.ChatID)
 		data := struct {
 			Summary string
 			Name    string

--- a/internal/handler/http.go
+++ b/internal/handler/http.go
@@ -1,31 +1,30 @@
 package handler
 
 import (
-	"database/sql"
 	"log"
 	"net/http"
 
 	"ragbot/internal/ai"
+	"ragbot/internal/repository"
 	"ragbot/internal/util"
 )
 
-// QueryRequest/Response модели JSON для эндпоинта /query
 type QueryRequest struct {
 	Question string `json:"question"`
 }
+
 type QueryResponse struct {
 	Answer string `json:"answer"`
 }
 
-// StartHTTP запускает HTTP-сервер с endpoint-ами /health, /query и /chat/{uuid}
-func StartHTTP(db *sql.DB, aiClient *ai.AIClient) {
+func StartHTTP(repo *repository.Repository, aiClient *ai.AIClient) {
 	defer util.Recover("StartHTTP")
 	http.HandleFunc("/", func(w http.ResponseWriter, _ *http.Request) {
 		w.WriteHeader(http.StatusOK)
 		w.Write([]byte("OK"))
 	})
 
-	http.HandleFunc("/chat/", ChatHandler(db))
+	http.HandleFunc("/chat/", ChatHandler(repo))
 
 	log.Println("HTTP server listening on :8080")
 	log.Fatal(http.ListenAndServe(":8080", nil))

--- a/internal/repository/repository.go
+++ b/internal/repository/repository.go
@@ -1,0 +1,237 @@
+package repository
+
+import (
+	"context"
+	"database/sql"
+	"time"
+
+	"github.com/pgvector/pgvector-go"
+	"ragbot/internal/models"
+)
+
+type Repository struct {
+	db *sql.DB
+}
+
+func New(db *sql.DB) *Repository { return &Repository{db: db} }
+
+// --- chunk operations ---
+
+// AddChunk inserts a new chunk. It returns true if the row was inserted.
+func (r *Repository) AddChunk(ctx context.Context, content, source string) (bool, error) {
+	res, err := r.db.ExecContext(ctx,
+		"INSERT INTO chunks(content, source) VALUES($1,$2) ON CONFLICT (content) DO NOTHING",
+		content, source,
+	)
+	if err != nil {
+		return false, err
+	}
+	rows, err := res.RowsAffected()
+	if err != nil {
+		return false, err
+	}
+	return rows > 0, nil
+}
+
+func (r *Repository) DeleteChunk(ctx context.Context, id int) error {
+	_, err := r.db.ExecContext(ctx, "DELETE FROM chunks WHERE id=$1", id)
+	return err
+}
+
+func (r *Repository) UpdateChunk(ctx context.Context, id int, content string) error {
+	_, err := r.db.ExecContext(ctx,
+		"UPDATE chunks SET content=$1, embedding=NULL, processed_at=NULL WHERE id=$2",
+		content, id,
+	)
+	return err
+}
+
+// GetUnprocessedChunks returns chunks without embedding limited by n.
+func (r *Repository) GetUnprocessedChunks(ctx context.Context, limit int) ([]models.Chunk, error) {
+	rows, err := r.db.QueryContext(ctx,
+		"SELECT id, content FROM chunks WHERE processed_at IS NULL LIMIT $1", limit)
+	if err != nil {
+		return nil, err
+	}
+	defer rows.Close()
+
+	var res []models.Chunk
+	for rows.Next() {
+		var c models.Chunk
+		if err := rows.Scan(&c.ID, &c.Content); err != nil {
+			return res, err
+		}
+		res = append(res, c)
+	}
+	return res, nil
+}
+
+func (r *Repository) UpdateChunkEmbedding(ctx context.Context, id int, vec []float32) error {
+	_, err := r.db.ExecContext(ctx,
+		"UPDATE chunks SET embedding=$1, processed_at=NOW() WHERE id=$2",
+		pgvector.NewVector(vec), id,
+	)
+	return err
+}
+
+func (r *Repository) SearchChunks(ctx context.Context, vec []float32, limit int) ([]string, error) {
+	rows, err := r.db.QueryContext(ctx,
+		"SELECT content FROM chunks WHERE processed_at IS NOT NULL ORDER BY embedding <-> $1 LIMIT $2",
+		pgvector.NewVector(vec), limit,
+	)
+	if err != nil {
+		return nil, err
+	}
+	defer rows.Close()
+	var out []string
+	for rows.Next() {
+		var c string
+		if err := rows.Scan(&c); err != nil {
+			return out, err
+		}
+		out = append(out, c)
+	}
+	return out, nil
+}
+
+func (r *Repository) GetChunkByExtID(ctx context.Context, source, extID string) (id int, createdAt time.Time, found bool, err error) {
+	err = r.db.QueryRowContext(ctx,
+		"SELECT id, created_at FROM chunks WHERE source=$1 AND ext_id=$2",
+		source, extID,
+	).Scan(&id, &createdAt)
+	if err == sql.ErrNoRows {
+		return 0, time.Time{}, false, nil
+	}
+	if err != nil {
+		return 0, time.Time{}, false, err
+	}
+	return id, createdAt, true, nil
+}
+
+func (r *Repository) InsertChunkWithExtID(ctx context.Context, content, source, extID string, createdAt time.Time) error {
+	_, err := r.db.ExecContext(ctx,
+		"INSERT INTO chunks(content, source, ext_id, created_at) VALUES($1,$2,$3,$4)",
+		content, source, extID, createdAt,
+	)
+	return err
+}
+
+func (r *Repository) UpdateChunkWithCreatedAt(ctx context.Context, id int, content string, createdAt time.Time) error {
+	_, err := r.db.ExecContext(ctx,
+		"UPDATE chunks SET content=$1, created_at=$2, embedding=NULL, processed_at=NULL WHERE id=$3",
+		content, createdAt, id,
+	)
+	return err
+}
+
+// --- conversation operations ---
+
+type ChatInfo struct {
+	ID      string
+	ChatID  int64
+	Summary sql.NullString
+	Name    sql.NullString
+	Phone   sql.NullString
+}
+
+type HistoryItem struct {
+	Role    string
+	Content string
+}
+
+func (r *Repository) EnsureSession(ctx context.Context, chatID int64) (string, error) {
+	var uuid string
+	err := r.db.QueryRowContext(ctx, `SELECT uuid FROM conversations WHERE chat_id=$1`, chatID).Scan(&uuid)
+	if err == sql.ErrNoRows {
+		err = r.db.QueryRowContext(ctx, `INSERT INTO conversations(chat_id) VALUES($1) RETURNING uuid`, chatID).Scan(&uuid)
+	}
+	return uuid, err
+}
+
+func (r *Repository) GetChatInfoByChatID(ctx context.Context, chatID int64) (ChatInfo, error) {
+	var info ChatInfo
+	err := r.db.QueryRowContext(ctx,
+		`SELECT uuid, summary, name, phone FROM conversations WHERE chat_id=$1`, chatID).Scan(&info.ID, &info.Summary, &info.Name, &info.Phone)
+	if err != nil {
+		return info, err
+	}
+	info.ChatID = chatID
+	return info, nil
+}
+
+func (r *Repository) GetChatInfoByUUID(ctx context.Context, uuid string) (ChatInfo, error) {
+	var info ChatInfo
+	err := r.db.QueryRowContext(ctx,
+		`SELECT chat_id, summary, name, phone FROM conversations WHERE uuid=$1`, uuid).Scan(&info.ChatID, &info.Summary, &info.Name, &info.Phone)
+	if err != nil {
+		return info, err
+	}
+	info.ID = uuid
+	return info, nil
+}
+
+func (r *Repository) UpdateSummary(ctx context.Context, chatID int64, summary string) error {
+	_, err := r.db.ExecContext(ctx,
+		`UPDATE conversations SET summary=$1, updated_at=NOW() WHERE chat_id=$2`, summary, chatID)
+	return err
+}
+
+func (r *Repository) UpdateName(ctx context.Context, chatID int64, name string) error {
+	_, err := r.db.ExecContext(ctx,
+		`UPDATE conversations SET name=$1, updated_at=NOW() WHERE chat_id=$2`, name, chatID)
+	return err
+}
+
+func (r *Repository) UpdatePhone(ctx context.Context, chatID int64, phone string) error {
+	_, err := r.db.ExecContext(ctx,
+		`UPDATE conversations SET phone=$1, updated_at=NOW() WHERE chat_id=$2`, phone, chatID)
+	return err
+}
+
+func (r *Repository) AppendHistory(ctx context.Context, chatID int64, role, text string) error {
+	_, err := r.db.ExecContext(ctx,
+		`INSERT INTO conversation_history(chat_id, role, content) VALUES ($1, $2, $3)`,
+		chatID, role, text,
+	)
+	return err
+}
+
+func (r *Repository) GetHistory(ctx context.Context, chatID int64, limit int) ([]HistoryItem, error) {
+	rows, err := r.db.QueryContext(ctx,
+		`SELECT role, content FROM conversation_history WHERE chat_id=$1 ORDER BY id DESC LIMIT $2`, chatID, limit)
+	if err != nil {
+		return nil, err
+	}
+	defer rows.Close()
+	var items []HistoryItem
+	for rows.Next() {
+		var it HistoryItem
+		if err := rows.Scan(&it.Role, &it.Content); err != nil {
+			return items, err
+		}
+		items = append(items, it)
+	}
+	// reverse
+	for i, j := 0, len(items)-1; i < j; i, j = i+1, j-1 {
+		items[i], items[j] = items[j], items[i]
+	}
+	return items, nil
+}
+
+func (r *Repository) GetFullHistory(ctx context.Context, chatID int64) ([]HistoryItem, error) {
+	rows, err := r.db.QueryContext(ctx,
+		`SELECT role, content FROM conversation_history WHERE chat_id=$1 ORDER BY id ASC`, chatID)
+	if err != nil {
+		return nil, err
+	}
+	defer rows.Close()
+	var items []HistoryItem
+	for rows.Next() {
+		var it HistoryItem
+		if err := rows.Scan(&it.Role, &it.Content); err != nil {
+			return items, err
+		}
+		items = append(items, it)
+	}
+	return items, nil
+}


### PR DESCRIPTION
## Summary
- extract all database operations into `repository` module
- refactor conversation helpers, bots and handlers to use repository
- check for duplicates when admin bot adds chunks
- adjust education sources and embedding worker to use repository
- update tests for new repository interface

## Testing
- `go test ./...`

------
https://chatgpt.com/codex/tasks/task_e_684424f0d9f08331bf6a6e79a170879d