### PR TITLE
Update call manager flow

### DIFF
--- a/internal/bot/admin.go
+++ b/internal/bot/admin.go
@@ -43,18 +43,12 @@ func StartAdminBot(repo *repository.Repository, token string, allowedIDs []int64
 		text := strings.TrimSpace(update.Message.Text)
 
 		if text == "/myid" {
-			replyToAdmin(chatID, fmt.Sprintf("Ваш CHAT ID: %d", chatID))
+			replyToAdmin(chatID, fmt.Sprintf(msgAdminMyIDFormat, chatID))
 			continue
 		}
 
 		if strings.HasPrefix(text, "/help") {
-			replyToAdmin(chatID,
-				"Команды администратора:\n"+
-					"/help — эта справка\n"+
-					"/myid — получить свой chat_id\n"+
-					"/delete <id> — удалить фрагмент по ID\n"+
-					"/update <id> <текст> — обновить фрагмент по ID\n\n"+
-					"Все остальное будет интерпретировано как запись в базу знаний")
+			replyToAdmin(chatID, msgAdminHelp)
 			continue
 		}
 
@@ -67,44 +61,44 @@ func StartAdminBot(repo *repository.Repository, token string, allowedIDs []int64
 			idStr := strings.TrimPrefix(text, "/delete ")
 			id, err := strconv.Atoi(idStr)
 			if err != nil {
-				replyToAdmin(chatID, "Неверный ID")
+				replyToAdmin(chatID, msgAdminInvalidID)
 				continue
 			}
 			if err := repo.DeleteChunk(context.Background(), id); err != nil {
-				replyToAdmin(chatID, "Ошибка удаления")
+				replyToAdmin(chatID, msgAdminDeleteError)
 				continue
 			}
-			replyToAdmin(chatID, fmt.Sprintf("Удалён фрагмент %d", id))
+			replyToAdmin(chatID, fmt.Sprintf(msgAdminDeletedFormat, id))
 
 		case strings.HasPrefix(text, "/update "):
 			parts := strings.SplitN(strings.TrimPrefix(text, "/update "), " ", 2)
 			if len(parts) < 2 {
-				replyToAdmin(chatID, "Использование: /update <id> <новый текст>")
+				replyToAdmin(chatID, msgAdminUpdateUsage)
 				continue
 			}
 			id, err := strconv.Atoi(parts[0])
 			if err != nil {
-				replyToAdmin(chatID, "Неверный ID")
+				replyToAdmin(chatID, msgAdminInvalidID)
 				continue
 			}
 			content := parts[1]
 			if err := repo.UpdateChunk(context.Background(), id, content); err != nil {
-				replyToAdmin(chatID, "Ошибка обновления")
+				replyToAdmin(chatID, msgAdminUpdateError)
 				continue
 			}
-			replyToAdmin(chatID, fmt.Sprintf("Обновлён фрагмент %d", id))
+			replyToAdmin(chatID, fmt.Sprintf(msgAdminUpdatedFormat, id))
 
 		default:
 			content := strings.Trim(text, " ")
 			added, err := repo.AddChunk(context.Background(), content, source)
 			if err != nil {
-				replyToAdmin(chatID, "Ошибка добавления")
+				replyToAdmin(chatID, msgAdminAddError)
 				continue
 			}
 			if added {
-				replyToAdmin(chatID, "Добавлено")
+				replyToAdmin(chatID, msgAdminAdded)
 			} else {
-				replyToAdmin(chatID, "Уже существует")
+				replyToAdmin(chatID, msgAdminExists)
 			}
 		}
 	}

--- a/internal/bot/buttons.go
+++ b/internal/bot/buttons.go
@@ -1,14 +1,30 @@
 package bot
 
-import tgbotapi "github.com/go-telegram-bot-api/telegram-bot-api/v5"
+import (
+	"fmt"
+
+	tgbotapi "github.com/go-telegram-bot-api/telegram-bot-api/v5"
+)
 
 func callMeBackButton(chatID int64) tgbotapi.MessageConfig {
 	keyboard := tgbotapi.NewInlineKeyboardMarkup(
 		tgbotapi.NewInlineKeyboardRow(
-			tgbotapi.NewInlineKeyboardButtonData("Хочу, чтобы мне перезвонили", "CALL_MANAGER"),
+			tgbotapi.NewInlineKeyboardButtonData(msgCallManagerButton, actionCallManager),
 		),
 	)
-	msg := tgbotapi.NewMessage(chatID, "Чтобы продолжить общение с нашим менеджером, нажмите кнопку:")
+	msg := tgbotapi.NewMessage(chatID, msgCallManagerPrompt)
+	msg.ReplyMarkup = keyboard
+	return msg
+}
+
+func confirmContactButton(chatID int64, name, phone string) tgbotapi.MessageConfig {
+	keyboard := tgbotapi.NewInlineKeyboardMarkup(
+		tgbotapi.NewInlineKeyboardRow(
+			tgbotapi.NewInlineKeyboardButtonData(msgConfirmYes, actionConfirmYes),
+			tgbotapi.NewInlineKeyboardButtonData(msgConfirmNo, actionConfirmNo),
+		),
+	)
+	msg := tgbotapi.NewMessage(chatID, fmt.Sprintf(msgConfirmContactFormat, name, phone))
 	msg.ReplyMarkup = keyboard
 	return msg
 }

--- a/internal/bot/messages.go
+++ b/internal/bot/messages.go
@@ -1,0 +1,40 @@
+package bot
+
+const (
+	msgCallManagerButton    = "Хочу, чтобы мне перезвонили"
+	msgCallManagerPrompt    = "Чтобы продолжить общение с нашим менеджером, нажмите кнопку:"
+	msgConfirmYes           = "Да"
+	msgConfirmNo            = "Нет"
+	msgConfirmContactFormat = "Мы нашли ваши контактные данные: %s, %s. Всё верно?"
+	msgAskName              = "Как к вам можно обращаться?"
+	msgAskPhone             = "Напишите ваш телефон для связи"
+	msgManagerWillCall      = "Наш менеджер свяжется с вами в ближайшее время"
+	msgAdminSummaryFormat   = "%s (%s): %s\n\n%s"
+	msgAdminErrorFormat     = "Возникла ошибка: %s"
+	msgUserError            = "Возникла ошибка. Пожалуйста, попробуйте повторить ваш запрос позднее."
+	msgAdminMyIDFormat      = "Ваш CHAT ID: %d"
+	msgAdminHelp            = "Команды администратора:\n" +
+		"/help — эта справка\n" +
+		"/myid — получить свой chat_id\n" +
+		"/delete <id> — удалить фрагмент по ID\n" +
+		"/update <id> <текст> — обновить фрагмент по ID\n\n" +
+		"Все остальное будет интерпретировано как запись в базу знаний"
+	msgAdminInvalidID     = "Неверный ID"
+	msgAdminDeleteError   = "Ошибка удаления"
+	msgAdminDeletedFormat = "Удалён фрагмент %d"
+	msgAdminUpdateUsage   = "Использование: /update <id> <новый текст>"
+	msgAdminUpdateError   = "Ошибка обновления"
+	msgAdminUpdatedFormat = "Обновлён фрагмент %d"
+	msgAdminAddError      = "Ошибка добавления"
+	msgAdminAdded         = "Добавлено"
+	msgAdminExists        = "Уже существует"
+)
+
+const (
+	promptUserPrefix      = "Пользователь: "
+	promptAssistantPrefix = "Помощник: "
+	promptSummarizeFormat = "Суммаризируй диалог пользователя в двух предложениях:\n%s\nРезюме:"
+	historyCallRequested  = "** хочет, чтобы ему перезвонили **"
+	historyConfirmYes     = "** подтвердил контактные данные **"
+	historyConfirmNo      = "** опроверг контактные данные **"
+)


### PR DESCRIPTION
## Summary
- add confirmation button for stored phone/name
- track contact confirmation state when user requests a call
- send admin notifications using stored info when confirmed
- centralize bot messages into constants

## Testing
- `go vet ./...`


------
https://chatgpt.com/codex/tasks/task_e_68450acb7fbc83319621f474f7f7a671