### PR TITLE
Add Tansultant client and user commands

### DIFF
--- a/internal/tansultant/client.go
+++ b/internal/tansultant/client.go
@@ -1,0 +1,71 @@
+package tansultant
+
+import (
+	"encoding/json"
+	"fmt"
+	"net/http"
+	"os"
+	"time"
+)
+
+// Client provides methods to get information from the Tansultant API.
+type Client struct {
+	HTTPClient      *http.Client
+	token           string
+	addressEndpoint string
+	pricesEndpoint  string
+}
+
+// NewClient creates a client using environment variables.
+func NewClient() *Client {
+	return &Client{
+		HTTPClient:      &http.Client{Timeout: 10 * time.Second},
+		token:           os.Getenv("TANSULTANT_API_ACCESS_TOKEN"),
+		addressEndpoint: os.Getenv("TANSULTANT_API_ADDRESS_ENDPOINT"),
+		pricesEndpoint:  os.Getenv("TANSULTANT_API_PRICES_ENDPOINT"),
+	}
+}
+
+func (c *Client) request(url string, v interface{}) error {
+	if url == "" {
+		return fmt.Errorf("endpoint not set")
+	}
+	req, err := http.NewRequest(http.MethodGet, url, nil)
+	if err != nil {
+		return err
+	}
+	if c.token != "" {
+		req.Header.Set("Authorization", "Bearer "+c.token)
+	}
+	resp, err := c.HTTPClient.Do(req)
+	if err != nil {
+		return err
+	}
+	defer resp.Body.Close()
+	if resp.StatusCode != http.StatusOK {
+		return fmt.Errorf("unexpected status: %s", resp.Status)
+	}
+	return json.NewDecoder(resp.Body).Decode(v)
+}
+
+// Branches returns available branches from the API.
+func (c *Client) Branches() ([]Branch, error) {
+	var res struct {
+		Branches []Branch `json:"branches"`
+	}
+	if err := c.request(c.addressEndpoint, &res); err != nil {
+		return nil, err
+	}
+	return res.Branches, nil
+}
+
+// Prices returns available passes and prices from the API.
+func (c *Client) Prices() ([]Price, error) {
+	var res struct {
+		Prices []Price `json:"prices"`
+	}
+	if err := c.request(c.pricesEndpoint, &res); err != nil {
+		return nil, err
+	}
+	return res.Prices, nil
+}

--- a/internal/tansultant/types.go
+++ b/internal/tansultant/types.go
@@ -1,0 +1,15 @@
+package tansultant
+
+// Branch represents a dance studio branch.
+type Branch struct {
+	Name        string `json:"name"`
+	Address     string `json:"address"`
+	ScheduleURL string `json:"schedule_url"`
+}
+
+// Price represents a subscription pass with its price and description.
+type Price struct {
+	Name        string `json:"name"`
+	Price       string `json:"price"`
+	Description string `json:"description"`
+}


### PR DESCRIPTION
## Summary
- add a minimal API client for Tansultant service
- implement `/address`, `/prices`, `/rasp`, `/call` commands in user bot
- show price details via callback buttons
- fetch addresses, schedules and prices via Tansultant API

## Testing
- `go test ./...`

------
https://chatgpt.com/codex/tasks/task_e_6846850c05548331bbf0c647f034e9ee