### PR TITLE
Improve web UI

### DIFF
--- a/internal/handler/chat.go
+++ b/internal/handler/chat.go
@@ -13,34 +13,37 @@ import (
 var chatTemplate = template.Must(template.New("chat").Parse(`<!DOCTYPE html>
 <html>
 <head>
-<meta charset="utf-8">
-<script src="https://cdn.tailwindcss.com"></script>
-<title>{{.Title}}</title>
+    <meta charset="utf-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1">
+    <script src="https://cdn.tailwindcss.com"></script>
+    <script>tailwind.config={darkMode:'media'}</script>
+    <title>{{.Title}}</title>
 </head>
-<body class="bg-gray-100">
-<div class="max-w-2xl mx-auto p-4">
+<body class="min-h-screen bg-gray-100 dark:bg-gray-900 text-gray-900 dark:text-gray-100">
+<div class="max-w-2xl mx-auto p-4 space-y-4">
+    <h1 class="text-2xl font-bold">{{.Title}}</h1>
     {{if .Name}}
-    <div class="bg-yellow-100 p-3 rounded shadow mb-4">
-        <h2 class="font-bold mb-2">Контакт</h2>
+    <div class="bg-yellow-50 dark:bg-yellow-900/20 p-4 rounded shadow">
+        <h2 class="font-semibold mb-1">Контакт</h2>
         <p>{{.Name}}</p>
-                {{if .Phone}}
-                <p>{{.Phone}}</p>
-                {{end}}
+        {{if .Phone}}
+        <p>{{.Phone}}</p>
+        {{end}}
     </div>
     {{end}}
     {{if .Summary}}
-    <div class="bg-yellow-100 p-3 rounded shadow mb-4">
-        <h2 class="font-bold mb-2">Суть обращения</h2>
+    <div class="bg-yellow-50 dark:bg-yellow-900/20 p-4 rounded shadow">
+        <h2 class="font-semibold mb-1">Суть обращения</h2>
         <p>{{.Summary}}</p>
     </div>
     {{end}}
-    <div class="bg-white p-4 rounded shadow">
+    <div class="bg-white dark:bg-gray-800 p-4 rounded shadow space-y-2">
         {{range .History}}
-        <div class="mb-2">
+        <div>
             {{if eq .Role "user"}}
             <span class="font-semibold">{{$.Name}}:</span>
             {{else}}
-            <span class="text-blue-600">Ассистент:</span>
+            <span class="text-blue-600 dark:text-blue-400">Ассистент:</span>
             {{end}}
             <span>{{.Content}}</span>
         </div>

--- a/internal/handler/chats.go
+++ b/internal/handler/chats.go
@@ -14,36 +14,41 @@ var chatsTemplate = template.Must(template.New("chats").Parse(`<!DOCTYPE html>
 <html>
 <head>
     <meta charset="utf-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1">
     <script src="https://cdn.tailwindcss.com"></script>
+    <script>tailwind.config={darkMode:'media'}</script>
     <title>Чаты</title>
 </head>
-<body class="bg-gray-100">
-<div class="max-w-4xl mx-auto p-4">
-    <table class="min-w-full bg-white rounded shadow">
-        <thead class="bg-gray-200">
+<body class="min-h-screen bg-gray-100 dark:bg-gray-900 text-gray-900 dark:text-gray-100">
+<div class="max-w-6xl mx-auto p-4 space-y-4">
+    <h1 class="text-2xl font-bold">Чаты</h1>
+    <div class="overflow-x-auto">
+    <table class="min-w-full bg-white dark:bg-gray-800 rounded shadow">
+        <thead class="bg-gray-200 dark:bg-gray-700">
         <tr>
-            <th class="px-2 py-1 text-left">Дата</th>
-            <th class="px-2 py-1 text-left">Чат</th>
-            <th class="px-2 py-1 text-left">Пользователь</th>
-            <th class="px-2 py-1 text-left">Лид</th>
-            <th class="px-2 py-1 text-left">Последнее сообщение</th>
+            <th class="px-4 py-2 text-left">Дата</th>
+            <th class="px-4 py-2 text-left">Чат</th>
+            <th class="px-4 py-2 text-left">Пользователь</th>
+            <th class="px-4 py-2 text-left">Лид</th>
+            <th class="px-4 py-2 text-left">Последнее сообщение</th>
         </tr>
         </thead>
         <tbody>
         {{range .Chats}}
-        <tr class="border-t">
-            <td class="px-2 py-1">{{.LastAt.Format "2006-01-02 15:04"}}</td>
-            <td class="px-2 py-1"><a class="text-blue-600" href="/chat/{{.ID}}">{{.Title.String}}</a></td>
-            <td class="px-2 py-1">{{.Name.String}} {{if .Username.Valid}}(@{{.Username.String}}){{end}}</td>
-            <td class="px-2 py-1">{{if .HasDeal}}✔{{else}}—{{end}}</td>
-            <td class="px-2 py-1">{{.LastMsg}}</td>
+        <tr class="border-t border-gray-200 dark:border-gray-700">
+            <td class="px-4 py-2 whitespace-nowrap">{{.LastAt.Format "2006-01-02 15:04"}}</td>
+            <td class="px-4 py-2 whitespace-nowrap"><a class="text-blue-600 dark:text-blue-400" href="/chat/{{.ID}}">{{.Title.String}}</a></td>
+            <td class="px-4 py-2 whitespace-nowrap">{{.Name.String}} {{if .Username.Valid}}(@{{.Username.String}}){{end}}</td>
+            <td class="px-4 py-2 whitespace-nowrap">{{if .HasDeal}}✔{{else}}—{{end}}</td>
+            <td class="px-4 py-2">{{.LastMsg}}</td>
         </tr>
         {{end}}
         </tbody>
     </table>
-    <div class="mt-4 flex justify-between">
-        {{if .HasPrev}}<a class="text-blue-600" href="?page={{.PrevPage}}">Предыдущая</a>{{else}}<span></span>{{end}}
-        {{if .HasNext}}<a class="text-blue-600" href="?page={{.NextPage}}">Следующая</a>{{end}}
+    </div>
+    <div class="flex justify-between">
+        {{if .HasPrev}}<a class="text-blue-600 dark:text-blue-400" href="?page={{.PrevPage}}">Предыдущая</a>{{else}}<span></span>{{end}}
+        {{if .HasNext}}<a class="text-blue-600 dark:text-blue-400" href="?page={{.NextPage}}">Следующая</a>{{end}}
     </div>
 </div>
 </body>

--- a/internal/handler/stats.go
+++ b/internal/handler/stats.go
@@ -1,0 +1,111 @@
+package handler
+
+import (
+	"database/sql"
+	"html/template"
+	"net/http"
+	"os"
+
+	"ragbot/internal/repository"
+	"ragbot/internal/util"
+)
+
+var statsTemplate = template.Must(template.New("stats").Parse(`<!DOCTYPE html>
+<html>
+<head>
+    <meta charset="utf-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1">
+    <script src="https://cdn.tailwindcss.com"></script>
+    <script>tailwind.config={darkMode:'media'}</script>
+    <title>Статистика</title>
+</head>
+<body class="min-h-screen bg-gray-100 dark:bg-gray-900 text-gray-900 dark:text-gray-100">
+<div class="max-w-3xl mx-auto p-4 space-y-6">
+    <h1 class="text-2xl font-bold">Статистика</h1>
+    <table class="min-w-full bg-white dark:bg-gray-800 rounded shadow divide-y divide-gray-200 dark:divide-gray-700">
+        <thead class="bg-gray-200 dark:bg-gray-700">
+            <tr>
+                <th class="px-4 py-2 text-left">Показатель</th>
+                <th class="px-4 py-2 text-left">Значение</th>
+            </tr>
+        </thead>
+        <tbody>
+            <tr><td class="px-4 py-2">Уникальные чаты</td><td class="px-4 py-2">{{.UniqueChats}}</td></tr>
+            <tr class="border-t border-gray-200 dark:border-gray-700"><td class="px-4 py-2">Лиды</td><td class="px-4 py-2">{{.Deals}}</td></tr>
+            <tr class="border-t border-gray-200 dark:border-gray-700"><td class="px-4 py-2">Конверсия</td><td class="px-4 py-2">{{printf "%.2f" .Conversion}}%</td></tr>
+            <tr class="border-t border-gray-200 dark:border-gray-700"><td class="px-4 py-2">/rasp</td><td class="px-4 py-2">{{.RaspCount}}</td></tr>
+            <tr class="border-t border-gray-200 dark:border-gray-700"><td class="px-4 py-2">/address</td><td class="px-4 py-2">{{.AddrCount}}</td></tr>
+            <tr class="border-t border-gray-200 dark:border-gray-700"><td class="px-4 py-2">/prices</td><td class="px-4 py-2">{{.PriceCount}}</td></tr>
+        </tbody>
+    </table>
+    <table class="min-w-full bg-white dark:bg-gray-800 rounded shadow divide-y divide-gray-200 dark:divide-gray-700">
+        <thead class="bg-gray-200 dark:bg-gray-700">
+            <tr>
+                <th class="px-4 py-2 text-left">Chat ID</th>
+                <th class="px-4 py-2 text-left">Username</th>
+                <th class="px-4 py-2 text-left">Сообщений до лида</th>
+            </tr>
+        </thead>
+        <tbody>
+            {{range .MsgCounts}}
+            <tr class="border-t border-gray-200 dark:border-gray-700">
+                <td class="px-4 py-2">{{.ChatID}}</td>
+                <td class="px-4 py-2">{{.Username.String}}</td>
+                <td class="px-4 py-2">{{.Count}}</td>
+            </tr>
+            {{end}}
+        </tbody>
+    </table>
+</div>
+</body>
+</html>`))
+
+func StatsHandler(repo *repository.Repository) http.HandlerFunc {
+	type msgCount struct {
+		ChatID   int64
+		Username sql.NullString
+		Count    int
+	}
+	return func(w http.ResponseWriter, r *http.Request) {
+		defer util.Recover("StatsHandler")
+		user, pass, ok := r.BasicAuth()
+		if !ok || user != os.Getenv("STATS_USER") || pass != os.Getenv("STATS_PASS") {
+			w.Header().Set("WWW-Authenticate", "Basic realm=restricted")
+			http.Error(w, "Unauthorized", http.StatusUnauthorized)
+			return
+		}
+		ctx := r.Context()
+		uniqueChats, _ := repo.CountUniqueChats(ctx)
+		deals, _ := repo.CountDeals(ctx)
+		conv := 0.0
+		if uniqueChats > 0 {
+			conv = float64(deals) / float64(uniqueChats) * 100
+		}
+		raspCount, _ := repo.CountCommandUsage(ctx, "/rasp")
+		addrCount, _ := repo.CountCommandUsage(ctx, "/address")
+		priceCount, _ := repo.CountCommandUsage(ctx, "/prices")
+		msgCountsRaw, _ := repo.MessageCountsBeforeDeal(ctx)
+		var msgCounts []msgCount
+		for _, m := range msgCountsRaw {
+			msgCounts = append(msgCounts, msgCount(m))
+		}
+		data := struct {
+			UniqueChats int
+			Deals       int
+			Conversion  float64
+			RaspCount   int
+			AddrCount   int
+			PriceCount  int
+			MsgCounts   []msgCount
+		}{
+			UniqueChats: uniqueChats,
+			Deals:       deals,
+			Conversion:  conv,
+			RaspCount:   raspCount,
+			AddrCount:   addrCount,
+			PriceCount:  priceCount,
+			MsgCounts:   msgCounts,
+		}
+		statsTemplate.Execute(w, data)
+	}
+}


### PR DESCRIPTION
## Summary
- modernize chat page with dark-mode support
- refine chats list styling and layout
- introduce stats page template using tables
- register new stats handler in server

## Testing
- `go list ./...`
- `go test ./...`


------
https://chatgpt.com/codex/tasks/task_e_68498b3a51d08331a6da2a895d4995cf