### PR TITLE
Enhance stats links

### DIFF
--- a/internal/bot/admin.go
+++ b/internal/bot/admin.go
@@ -8,6 +8,7 @@ import (
 	"strings"
 
 	tgbotapi "github.com/go-telegram-bot-api/telegram-bot-api/v5"
+	"ragbot/internal/config"
 	"ragbot/internal/repository"
 	"ragbot/internal/util"
 )
@@ -137,6 +138,14 @@ func handleAdminCommand(repo *repository.Repository, update tgbotapi.Update, cha
 			}
 			replyToAdminMarkdownV2(chatID, sb.String())
 			return true
+		case "stats":
+			url := fmt.Sprintf("%s/stats", config.Config.BaseURL)
+			replyToAdmin(chatID, url)
+			return true
+		case "chats":
+			url := fmt.Sprintf("%s/chats", config.Config.BaseURL)
+			replyToAdmin(chatID, url)
+			return true
 		}
 	}
 	return false
@@ -149,6 +158,8 @@ func registerAdminCommands() {
 		{Command: "update", Description: "Обновить фрагмент: /update <id> <текст>"},
 		{Command: "delete", Description: "Удалить фрагмент: /delete <id>"},
 		{Command: "list", Description: "Показать все фрагменты"},
+		{Command: "stats", Description: "Открыть статистику"},
+		{Command: "chats", Description: "Открыть список чатов"},
 	}
 
 	_, err := adminBot.Request(tgbotapi.NewSetMyCommands(commands...))

--- a/internal/handler/entry.go
+++ b/internal/handler/entry.go
@@ -26,7 +26,9 @@ func HandleEntry(repo *repository.Repository) http.HandlerFunc {
 
 		if config.Config.UserTelegramBotName != "" {
 			url := fmt.Sprintf(telegramWebUrlFormat, config.Config.UserTelegramBotName)
-			http.Redirect(w, r, url, http.StatusTemporaryRedirect)
+			w.Header().Set("Content-Type", "text/html; charset=utf-8")
+			fmt.Fprintf(w, "<!DOCTYPE html><html><head><meta charset=\"utf-8\"><title>Redirect</title><script>window.location.replace('%s');</script></head><body><noscript><a href=\"%s\">Перейти в чат с ассистентом</a></noscript></body></html>", url, url)
+			return
 		}
 
 		w.WriteHeader(http.StatusOK)


### PR DESCRIPTION
## Summary
- show links to chat pages in stats table
- extend statistics rows for visits and conversions
- add admin bot commands to open stats and chats pages
- track unique visits by ip and user agent
- client-side redirect with noscript fallback on landing page

## Testing
- `go test ./...`


------
https://chatgpt.com/codex/tasks/task_e_684a4acc86ac833186632fc5e2b43e9e