### PR TITLE
Add buttons for admin stats/chats; refactor user buttons

### DIFF
--- a/internal/bot/admin.go
+++ b/internal/bot/admin.go
@@ -140,11 +140,11 @@ func handleAdminCommand(repo *repository.Repository, update tgbotapi.Update, cha
 			return true
 		case "stats":
 			url := fmt.Sprintf("%s/stats", config.Config.BaseURL)
-			replyToAdmin(chatID, url)
+			adminBot.Send(statsButton(chatID, url))
 			return true
 		case "chats":
 			url := fmt.Sprintf("%s/chats", config.Config.BaseURL)
-			replyToAdmin(chatID, url)
+			adminBot.Send(chatsButton(chatID, url))
 			return true
 		}
 	}

--- a/internal/bot/buttons.go
+++ b/internal/bot/buttons.go
@@ -4,6 +4,7 @@ import (
 	"fmt"
 
 	tgbotapi "github.com/go-telegram-bot-api/telegram-bot-api/v5"
+	"ragbot/internal/tansultant"
 )
 
 func callMeBackButton(chatID int64) tgbotapi.MessageConfig {
@@ -27,4 +28,73 @@ func confirmContactButton(chatID int64, name, phone string) tgbotapi.MessageConf
 	msg := tgbotapi.NewMessage(chatID, fmt.Sprintf(msgConfirmContactFormat, name, phone))
 	msg.ReplyMarkup = keyboard
 	return msg
+}
+
+func statsButton(chatID int64, url string) tgbotapi.MessageConfig {
+	keyboard := tgbotapi.NewInlineKeyboardMarkup(
+		tgbotapi.NewInlineKeyboardRow(
+			tgbotapi.NewInlineKeyboardButtonURL(msgStatsButton, url),
+		),
+	)
+	msg := tgbotapi.NewMessage(chatID, msgStatsPrompt)
+	msg.ReplyMarkup = keyboard
+	return msg
+}
+
+func chatsButton(chatID int64, url string) tgbotapi.MessageConfig {
+	keyboard := tgbotapi.NewInlineKeyboardMarkup(
+		tgbotapi.NewInlineKeyboardRow(
+			tgbotapi.NewInlineKeyboardButtonURL(msgChatsButton, url),
+		),
+	)
+	msg := tgbotapi.NewMessage(chatID, msgChatsPrompt)
+	msg.ReplyMarkup = keyboard
+	return msg
+}
+
+func scheduleButtons(chatID int64, branches []tansultant.Branch) tgbotapi.MessageConfig {
+	var rows [][]tgbotapi.InlineKeyboardButton
+	for _, b := range branches {
+		rows = append(rows, tgbotapi.NewInlineKeyboardRow(
+			tgbotapi.NewInlineKeyboardButtonURL(fmt.Sprintf(msgScheduleLinkFormat, b.Title), b.ScheduleLink),
+		))
+	}
+	msg := tgbotapi.NewMessage(chatID, msgScheduleTitle)
+	msg.ReplyMarkup = tgbotapi.NewInlineKeyboardMarkup(rows...)
+	return msg
+}
+
+func priceButtons(chatID int64, prices []tansultant.Price) (tgbotapi.MessageConfig, map[string]string) {
+	var rows [][]tgbotapi.InlineKeyboardButton
+	m := make(map[string]string)
+	for i, p := range prices {
+		key := fmt.Sprintf("PRICE_%d", i)
+		properties := ""
+		if p.Hours != "" {
+			properties += fmt.Sprintf(msgPassHoursFormat, p.Hours)
+		}
+		if p.GuestVisits != "" {
+			properties += fmt.Sprintf(msgGuestVisitsFormat, p.GuestVisits)
+		}
+		if p.FreezeAllowed != "" {
+			properties += msgPassFreezeAllowed
+		}
+		if p.Lifetime != "" {
+			properties += fmt.Sprintf(msgPassLifetimeFormat, p.Lifetime)
+		}
+		properties = tgbotapi.EscapeText(tgbotapi.ModeMarkdownV2, properties)
+		if p.Price != "" {
+			properties += fmt.Sprintf(msgPriceFormat, p.Price)
+		}
+		name := tgbotapi.EscapeText(tgbotapi.ModeMarkdownV2, p.Name)
+		description := tgbotapi.EscapeText(tgbotapi.ModeMarkdownV2, p.Description)
+		m[key] = fmt.Sprintf(msgPriceDescriptionFormat, name, description, properties)
+		label := fmt.Sprintf(msgPriceButtonFormat, p.Name, p.Price)
+		rows = append(rows, tgbotapi.NewInlineKeyboardRow(
+			tgbotapi.NewInlineKeyboardButtonData(label, key),
+		))
+	}
+	msg := tgbotapi.NewMessage(chatID, msgPricesTitle)
+	msg.ReplyMarkup = tgbotapi.NewInlineKeyboardMarkup(rows...)
+	return msg, m
 }

--- a/internal/bot/messages.go
+++ b/internal/bot/messages.go
@@ -58,6 +58,10 @@ const (
 	msgPassLifetimeFormat     = "• Срок действия: %s дн.\n"
 	msgPriceFormat            = "• *Стоимость: %s₽*\n"
 	msgScheduleLinkFormat     = "Расписание студии %s"
+	msgStatsPrompt            = "Чтобы открыть статистику, нажмите кнопку:"
+	msgStatsButton            = "Статистика"
+	msgChatsPrompt            = "Чтобы открыть список чатов, нажмите кнопку:"
+	msgChatsButton            = "Чаты"
 )
 
 const (

--- a/internal/bot/user.go
+++ b/internal/bot/user.go
@@ -217,15 +217,7 @@ func sendSchedule(chatID int64) {
 		replyToUser(chatID, msgInfoUnavailable)
 		return
 	}
-	var rows [][]tgbotapi.InlineKeyboardButton
-	for _, b := range branches {
-		rows = append(rows, tgbotapi.NewInlineKeyboardRow(
-			tgbotapi.NewInlineKeyboardButtonURL(fmt.Sprintf(msgScheduleLinkFormat, b.Title), b.ScheduleLink),
-		))
-	}
-	msg := tgbotapi.NewMessage(chatID, msgScheduleTitle)
-	msg.ReplyMarkup = tgbotapi.NewInlineKeyboardMarkup(rows...)
-	userBot.Send(msg)
+	userBot.Send(scheduleButtons(chatID, branches))
 }
 
 func sendPrices(chatID int64) {
@@ -239,39 +231,10 @@ func sendPrices(chatID int64) {
 		replyToUser(chatID, msgInfoUnavailable)
 		return
 	}
-	var rows [][]tgbotapi.InlineKeyboardButton
 	priceMu.Lock()
-	priceMap = make(map[string]string)
-	for i, p := range prices {
-		key := fmt.Sprintf("PRICE_%d", i)
-		properties := ""
-		if p.Hours != "" {
-			properties = properties + fmt.Sprintf(msgPassHoursFormat, p.Hours)
-		}
-		if p.GuestVisits != "" {
-			properties = properties + fmt.Sprintf(msgGuestVisitsFormat, p.GuestVisits)
-		}
-		if p.FreezeAllowed != "" {
-			properties = properties + msgPassFreezeAllowed
-		}
-		if p.Lifetime != "" {
-			properties = properties + fmt.Sprintf(msgPassLifetimeFormat, p.Lifetime)
-		}
-		properties = tgbotapi.EscapeText(tgbotapi.ModeMarkdownV2, properties)
-		if p.Price != "" {
-			properties = properties + fmt.Sprintf(msgPriceFormat, p.Price)
-		}
-		name := tgbotapi.EscapeText(tgbotapi.ModeMarkdownV2, p.Name)
-		description := tgbotapi.EscapeText(tgbotapi.ModeMarkdownV2, p.Description)
-		priceMap[key] = fmt.Sprintf(msgPriceDescriptionFormat, name, description, properties)
-		label := fmt.Sprintf(msgPriceButtonFormat, p.Name, p.Price)
-		rows = append(rows, tgbotapi.NewInlineKeyboardRow(
-			tgbotapi.NewInlineKeyboardButtonData(label, key),
-		))
-	}
+	msg, m := priceButtons(chatID, prices)
+	priceMap = m
 	priceMu.Unlock()
-	msg := tgbotapi.NewMessage(chatID, msgPricesTitle)
-	msg.ReplyMarkup = tgbotapi.NewInlineKeyboardMarkup(rows...)
 	userBot.Send(msg)
 }
 


### PR DESCRIPTION
## Summary
- replace admin /stats and /chats replies with URL buttons
- centralize keyboard builders in `buttons.go`
- update user bot to use new button helpers
- define new message strings for admin buttons

## Testing
- `go test ./...`

------
https://chatgpt.com/codex/tasks/task_e_684a514d4f0c833199c2d59dbd246bcd