### PR TITLE
Implement channel command

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -22,6 +22,7 @@ USER_TELEGRAM_BOT_NAME=something_bot
 USER_TELEGRAM_TOKEN=something_bot_token
 ADMIN_TELEGRAM_TOKEN=admin_bot_token
 ADMIN_CHAT_IDS=123,456,789
+TELEGRAM_CHANNEL=your_channel_name
 
 # OpenAI Integration Configuration
 OPENAI_API_KEY=open_ai_token

--- a/README.md
+++ b/README.md
@@ -50,6 +50,7 @@
 | `CERTBOT_STAGING` | Добавить `--staging` для тестовых сертификатов (опционально) |
 | `STATS_USER` | Логин для доступа к странице статистики |
 | `STATS_PASS` | Пароль для доступа к странице статистики |
+| `TELEGRAM_CHANNEL` | Адрес Telegram-канала (без @) |
 
 ## Установка
 
@@ -71,6 +72,7 @@ POSTGRES_PASSWORD=your_secure_password_here
 USER_TELEGRAM_TOKEN=your_user_telegram_token
 ADMIN_TELEGRAM_TOKEN=your_admin_telegram_token
 ADMIN_CHAT_IDS=123456789,987654321
+TELEGRAM_CHANNEL=your_channel_name
 
 # Переменные для продакшн-развертывания
 DOMAIN_NAME=yourdomain.com

--- a/internal/bot/buttons.go
+++ b/internal/bot/buttons.go
@@ -52,6 +52,18 @@ func chatsButton(chatID int64, url string) tgbotapi.MessageConfig {
 	return msg
 }
 
+func channelButton(chatID int64, channel string) tgbotapi.MessageConfig {
+	url := fmt.Sprintf("https://t.me/%s", channel)
+	keyboard := tgbotapi.NewInlineKeyboardMarkup(
+		tgbotapi.NewInlineKeyboardRow(
+			tgbotapi.NewInlineKeyboardButtonURL("@"+channel, url),
+		),
+	)
+	msg := tgbotapi.NewMessage(chatID, msgChannelPrompt)
+	msg.ReplyMarkup = keyboard
+	return msg
+}
+
 func scheduleButtons(chatID int64, branches []tansultant.Branch) tgbotapi.MessageConfig {
 	var rows [][]tgbotapi.InlineKeyboardButton
 	for _, b := range branches {

--- a/internal/bot/messages.go
+++ b/internal/bot/messages.go
@@ -62,6 +62,7 @@ const (
 	msgStatsButton            = "Статистика"
 	msgChatsPrompt            = "Чтобы открыть список чатов, нажмите кнопку:"
 	msgChatsButton            = "Чаты"
+	msgChannelPrompt          = "Чтобы открыть телеграм-канал ШТБП, нажмите кнопку:"
 )
 
 const (

--- a/internal/bot/user.go
+++ b/internal/bot/user.go
@@ -81,6 +81,7 @@ func registerUserCommands() {
 		{Command: "prices", Description: "Показать цены на обучение"},
 		{Command: "rasp", Description: "Показать расписание занятий"},
 		{Command: "call", Description: "Заказать обратный звонок от менеджера"},
+		{Command: "channel", Description: "Перейти в телеграм-канал ШТБП"},
 	}
 
 	_, err := userBot.Request(tgbotapi.NewSetMyCommands(commands...))
@@ -180,6 +181,9 @@ func handleUserCommand(update tgbotapi.Update, chatID int64) bool {
 			return true
 		case "call":
 			userBot.Send(callMeBackButton(chatID))
+			return true
+		case "channel":
+			userBot.Send(channelButton(chatID, config.Config.TelegramChannel))
 			return true
 		default:
 		}

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -24,6 +24,7 @@ type AppConfig struct {
 	AmoAccessToken      string
 	AdminUsername       string
 	AdminPassword       string
+	TelegramChannel     string
 }
 
 type AppSettings struct {
@@ -76,6 +77,7 @@ func LoadConfig() *AppConfig {
 	ymlURL := os.Getenv("YANDEX_YML_URL")
 	amoDomain := os.Getenv("AMO_DOMAIN")
 	amoToken := os.Getenv("AMO_ACCESS_TOKEN")
+	telegramChannel := os.Getenv("TELEGRAM_CHANNEL")
 	useExternal := false
 	if os.Getenv("USE_EXTERNAL_SOURCE") == "true" {
 		useExternal = true
@@ -108,6 +110,7 @@ func LoadConfig() *AppConfig {
 		YandexYMLURL:        ymlURL,
 		AmoDomain:           amoDomain,
 		AmoAccessToken:      amoToken,
+		TelegramChannel:     telegramChannel,
 		AdminUsername:       util.GetEnvString("ADMIN_USERNAME", "admin"),
 		AdminPassword:       util.GetEnvString("ADMIN_PASSWORD", "secret"),
 	}


### PR DESCRIPTION
## Summary
- add `TELEGRAM_CHANNEL` to config and environment example
- expose new `/channel` command in user bot
- send button pointing to configured Telegram channel
- document new setting in README

## Testing
- `go vet ./...`
- `go build ./...`


------
https://chatgpt.com/codex/tasks/task_e_684a6462d9f8833194097c525149e148